### PR TITLE
#20 Create CI workflow for Android APK builds

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,42 @@
+name: Build Android
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.x'
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build APK
+        run: flutter build apk --debug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: build/app/outputs/flutter-apk/app-debug.apk
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Created GitHub Actions workflow for Android APK builds
- Builds debug APK on every push/PR to main
- Uploads APK as downloadable artifact

## Workflow Details

| Step | Purpose |
|------|---------|
| Setup Java 17 | Required for Android Gradle |
| Setup Flutter | Install Flutter SDK |
| Build APK | `flutter build apk --debug` |
| Upload artifact | Store APK for 14 days |

## Test plan
- [ ] Workflow triggers on PR
- [ ] APK builds successfully
- [ ] APK artifact is downloadable
- [ ] APK installs on Android device/emulator

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)