### PR TITLE
#21 Create CI workflow for iOS builds

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,29 @@
+name: Build iOS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-ios:
+    name: Build iOS (unsigned)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.x'
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build iOS (debug, no codesign)
+        run: flutter build ios --debug --no-codesign


### PR DESCRIPTION
## Summary
- Created GitHub Actions workflow for iOS builds
- Uses macOS runner for iOS compilation
- Builds debug iOS app without code signing
- Serves as iOS platform compilation check

## Workflow Details

| Step | Purpose |
|------|---------|
| Setup Flutter | Install Flutter SDK on macOS |
| Install deps | Get dependencies |
| Build iOS | `flutter build ios --debug --no-codesign` |

## Notes
- No code signing (would require Apple Developer credentials)
- Debug build only (sufficient for compilation verification)
- macOS runner is slower but required for iOS builds

## Test plan
- [ ] Workflow triggers on PR
- [ ] iOS build compiles without errors
- [ ] Build completes on macOS runner

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)