### PR TITLE
#28 Implement recipe deletion in repository

### DIFF
--- a/lib/repositories/recipe_repository.dart
+++ b/lib/repositories/recipe_repository.dart
@@ -38,4 +38,13 @@ class RecipeRepository {
   Future<Recipe?> getRecipeById(int id) async {
     return await _isar.recipes.get(id);
   }
+
+  /// Deletes a recipe from the database by its ID.
+  ///
+  /// Returns true if the recipe was deleted, false if it didn't exist.
+  Future<bool> deleteRecipe(int id) async {
+    return await _isar.writeTxn(() async {
+      return await _isar.recipes.delete(id);
+    });
+  }
 }

--- a/test/repositories/recipe_repository_test.dart
+++ b/test/repositories/recipe_repository_test.dart
@@ -192,5 +192,53 @@ void main() {
         expect(retrieved!.title, equals('Recipe 1'));
       });
     });
+
+    group('deleteRecipe', () {
+      test('should delete recipe and return true', () async {
+        final recipe = await repository.addRecipe(Recipe()
+          ..title = 'Recipe to Delete'
+          ..ingredients = []
+          ..instructions = []);
+
+        final deleted = await repository.deleteRecipe(recipe.id);
+
+        expect(deleted, isTrue);
+      });
+
+      test('should return false for non-existent ID', () async {
+        final deleted = await repository.deleteRecipe(99999);
+
+        expect(deleted, isFalse);
+      });
+
+      test('should remove recipe from database', () async {
+        final recipe = await repository.addRecipe(Recipe()
+          ..title = 'Recipe to Delete'
+          ..ingredients = []
+          ..instructions = []);
+
+        await repository.deleteRecipe(recipe.id);
+        final retrieved = await repository.getRecipeById(recipe.id);
+
+        expect(retrieved, isNull);
+      });
+
+      test('should not affect other recipes', () async {
+        final recipe1 = await repository.addRecipe(Recipe()
+          ..title = 'Recipe 1'
+          ..ingredients = []
+          ..instructions = []);
+        final recipe2 = await repository.addRecipe(Recipe()
+          ..title = 'Recipe 2'
+          ..ingredients = []
+          ..instructions = []);
+
+        await repository.deleteRecipe(recipe1.id);
+
+        final retrieved = await repository.getRecipeById(recipe2.id);
+        expect(retrieved, isNotNull);
+        expect(retrieved!.title, equals('Recipe 2'));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Implemented `deleteRecipe(int id)` method in RecipeRepository
- Returns true if recipe was deleted, false if it didn't exist
- Uses write transaction for data integrity

## Closes
Closes #28

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] `flutter test` passes (4 unit tests for deleteRecipe)
- [ ] CI workflows pass

### Test Coverage
- Deletes recipe and returns true
- Returns false for non-existent ID
- Removes recipe from database
- Does not affect other recipes