### PR TITLE
#30 Create Isar database provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Isar native binaries (downloaded during tests)
+libisar.so
+libisar.dylib
+isar.dll

--- a/lib/providers/database_provider.dart
+++ b/lib/providers/database_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar/isar.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/recipe.dart';
+
+/// Provider that initializes and provides the Isar database instance.
+///
+/// This is the single source of truth for database access. The database
+/// is opened once and shared across all dependent providers.
+final isarProvider = FutureProvider<Isar>((ref) async {
+  final dir = await getApplicationDocumentsDirectory();
+
+  final isar = await Isar.open(
+    [RecipeSchema],
+    directory: dir.path,
+  );
+
+  ref.onDispose(() async {
+    await isar.close();
+  });
+
+  return isar;
+});

--- a/test/providers/database_provider_test.dart
+++ b/test/providers/database_provider_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:sodium/models/recipe.dart';
+import 'package:sodium/providers/database_provider.dart';
+
+void main() {
+  late Isar testIsar;
+
+  setUp(() async {
+    await Isar.initializeIsarCore(download: true);
+    testIsar = await Isar.open(
+      [RecipeSchema],
+      directory: '',
+    );
+  });
+
+  tearDown(() async {
+    await testIsar.close(deleteFromDisk: true);
+  });
+
+  group('isarProvider', () {
+    test('should be a FutureProvider<Isar>', () {
+      expect(isarProvider, isA<FutureProvider<Isar>>());
+    });
+
+    test('should provide Isar instance when overridden', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final isar = await container.read(isarProvider.future);
+
+      expect(isar, isA<Isar>());
+      expect(isar, equals(testIsar));
+    });
+
+    test('should allow recipe operations through overridden provider',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final isar = await container.read(isarProvider.future);
+
+      // Write a recipe
+      await isar.writeTxn(() async {
+        await isar.recipes.put(Recipe()
+          ..title = 'Test Recipe'
+          ..ingredients = ['ingredient']
+          ..instructions = ['step']);
+      });
+
+      // Read it back
+      final recipes = await isar.recipes.where().findAll();
+
+      expect(recipes.length, equals(1));
+      expect(recipes.first.title, equals('Test Recipe'));
+    });
+
+    test('should expose loading state', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final asyncValue = container.read(isarProvider);
+
+      // Initially might be loading or already loaded depending on timing
+      expect(
+        asyncValue,
+        anyOf(
+          isA<AsyncLoading<Isar>>(),
+          isA<AsyncData<Isar>>(),
+        ),
+      );
+    });
+
+    test('should expose data state after loading', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Wait for the future to complete
+      await container.read(isarProvider.future);
+
+      final asyncValue = container.read(isarProvider);
+
+      expect(asyncValue, isA<AsyncData<Isar>>());
+      expect(asyncValue.value, equals(testIsar));
+    });
+
+    test('should expose error state on failure', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async {
+            throw Exception('Database initialization failed');
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Wait for the future to complete (with error)
+      try {
+        await container.read(isarProvider.future);
+      } catch (_) {
+        // Expected to throw
+      }
+
+      final asyncValue = container.read(isarProvider);
+
+      expect(asyncValue, isA<AsyncError<Isar>>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create `isarProvider` FutureProvider in `lib/providers/database_provider.dart`
- Initialize Isar database with Recipe schema
- Use path_provider for documents directory
- Handle disposal on provider cleanup
- Add comprehensive unit tests for provider states
- Update .gitignore to exclude Isar native binaries

## Test plan
- [x] Provider type test passes
- [x] Override provider test passes
- [x] Recipe operations test passes
- [x] Loading state test passes
- [x] Data state test passes
- [x] Error state test passes

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)