### PR TITLE
#31 Create recipe repository provider

### DIFF
--- a/lib/providers/recipe_provider.dart
+++ b/lib/providers/recipe_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../repositories/recipe_repository.dart';
+import 'database_provider.dart';
+
+/// Provider that creates and provides the RecipeRepository instance.
+///
+/// This provider depends on [isarProvider] and creates a repository
+/// that can be used for all recipe CRUD operations.
+final recipeRepositoryProvider = Provider<RecipeRepository>((ref) {
+  final isar = ref.watch(isarProvider).requireValue;
+  return RecipeRepository(isar);
+});

--- a/test/providers/recipe_provider_test.dart
+++ b/test/providers/recipe_provider_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:sodium/models/recipe.dart';
+import 'package:sodium/providers/database_provider.dart';
+import 'package:sodium/providers/recipe_provider.dart';
+import 'package:sodium/repositories/recipe_repository.dart';
+
+void main() {
+  late Isar testIsar;
+
+  setUp(() async {
+    await Isar.initializeIsarCore(download: true);
+    testIsar = await Isar.open(
+      [RecipeSchema],
+      directory: '',
+    );
+  });
+
+  tearDown(() async {
+    await testIsar.close(deleteFromDisk: true);
+  });
+
+  group('recipeRepositoryProvider', () {
+    test('should be a Provider<RecipeRepository>', () {
+      expect(recipeRepositoryProvider, isA<Provider<RecipeRepository>>());
+    });
+
+    test('should provide RecipeRepository instance', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Wait for isar to be ready
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+
+      expect(repository, isA<RecipeRepository>());
+    });
+
+    test('should use Isar instance from isarProvider', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+
+      // Verify by performing an operation
+      final recipe = await repository.addRecipe(Recipe()
+        ..title = 'Test Recipe'
+        ..ingredients = ['ingredient']
+        ..instructions = ['step']);
+
+      expect(recipe.id, isNot(Isar.autoIncrement));
+
+      // Verify it's in the database
+      final retrieved = await testIsar.recipes.get(recipe.id);
+      expect(retrieved, isNotNull);
+      expect(retrieved!.title, equals('Test Recipe'));
+    });
+
+    test('should allow CRUD operations through repository', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+
+      // Create
+      final recipe = await repository.addRecipe(Recipe()
+        ..title = 'CRUD Test'
+        ..ingredients = ['item1']
+        ..instructions = ['do something']);
+
+      // Read
+      final fetched = await repository.getRecipeById(recipe.id);
+      expect(fetched, isNotNull);
+      expect(fetched!.title, equals('CRUD Test'));
+
+      // Update
+      fetched.title = 'Updated CRUD Test';
+      await repository.updateRecipe(fetched);
+
+      final updated = await repository.getRecipeById(recipe.id);
+      expect(updated!.title, equals('Updated CRUD Test'));
+
+      // Delete
+      final deleted = await repository.deleteRecipe(recipe.id);
+      expect(deleted, isTrue);
+
+      final afterDelete = await repository.getRecipeById(recipe.id);
+      expect(afterDelete, isNull);
+    });
+
+    test('should support search operations', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+
+      await repository.addRecipe(Recipe()
+        ..title = 'Chocolate Cake'
+        ..ingredients = []
+        ..instructions = []);
+      await repository.addRecipe(Recipe()
+        ..title = 'Vanilla Ice Cream'
+        ..ingredients = []
+        ..instructions = []);
+
+      final results = await repository.searchRecipes('Chocolate');
+
+      expect(results.length, equals(1));
+      expect(results.first.title, equals('Chocolate Cake'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create `recipeRepositoryProvider` in `lib/providers/recipe_provider.dart`
- Inject Isar instance from `isarProvider`
- Provide RecipeRepository for CRUD operations throughout the app
- Add comprehensive unit tests

## Test plan
- [x] Provider type test passes
- [x] Provider instance test passes
- [x] Isar injection test passes
- [x] CRUD operations test passes
- [x] Search operations test passes

**Note:** This PR depends on PR #77 and is based on branch `feature/30-isar-database-provider`.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)