### PR TITLE
#32 Create recipes list provider

### DIFF
--- a/lib/providers/recipe_provider.dart
+++ b/lib/providers/recipe_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../models/recipe.dart';
 import '../repositories/recipe_repository.dart';
 import 'database_provider.dart';
 
@@ -10,4 +11,13 @@ import 'database_provider.dart';
 final recipeRepositoryProvider = Provider<RecipeRepository>((ref) {
   final isar = ref.watch(isarProvider).requireValue;
   return RecipeRepository(isar);
+});
+
+/// Provider that fetches and manages the list of all recipes.
+///
+/// Returns recipes sorted by creation date (newest first).
+/// Automatically refreshes when invalidated.
+final recipesProvider = FutureProvider<List<Recipe>>((ref) async {
+  final repository = ref.watch(recipeRepositoryProvider);
+  return repository.getAllRecipes();
 });


### PR DESCRIPTION
## Summary
- Add `recipesProvider` FutureProvider to fetch all recipes
- Returns recipes sorted by creation date (newest first)
- Supports invalidation for refresh
- Add comprehensive unit tests (6 new tests)

## Test plan
- [x] Provider type test passes
- [x] Empty list test passes
- [x] Return all recipes test passes
- [x] Sorting test passes
- [x] Loading state test passes
- [x] Refresh on invalidate test passes

**Note:** This PR depends on PR #78 and is based on branch `feature/31-recipe-repository-provider`.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)