### PR TITLE
#33 Create recipe search provider

### DIFF
--- a/lib/providers/recipe_provider.dart
+++ b/lib/providers/recipe_provider.dart
@@ -21,3 +21,14 @@ final recipesProvider = FutureProvider<List<Recipe>>((ref) async {
   final repository = ref.watch(recipeRepositoryProvider);
   return repository.getAllRecipes();
 });
+
+/// Provider that searches for recipes by title.
+///
+/// Takes a search query as parameter and returns matching recipes.
+/// The search is case-insensitive. Returns all recipes for empty query.
+/// Results are sorted by creation date (newest first).
+final recipeSearchProvider =
+    FutureProvider.family<List<Recipe>, String>((ref, query) async {
+  final repository = ref.watch(recipeRepositoryProvider);
+  return repository.searchRecipes(query);
+});

--- a/test/providers/recipe_provider_test.dart
+++ b/test/providers/recipe_provider_test.dart
@@ -265,4 +265,140 @@ void main() {
       expect(recipes.first.title, equals('New Recipe'));
     });
   });
+
+  group('recipeSearchProvider', () {
+    test('should be a FutureProvider.family', () {
+      expect(
+        recipeSearchProvider,
+        isA<FutureProviderFamily<List<Recipe>, String>>(),
+      );
+    });
+
+    test('should return matching recipes', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+      await repository.addRecipe(Recipe()
+        ..title = 'Chocolate Cake'
+        ..ingredients = []
+        ..instructions = []);
+      await repository.addRecipe(Recipe()
+        ..title = 'Vanilla Pudding'
+        ..ingredients = []
+        ..instructions = []);
+      await repository.addRecipe(Recipe()
+        ..title = 'Chocolate Mousse'
+        ..ingredients = []
+        ..instructions = []);
+
+      final results =
+          await container.read(recipeSearchProvider('Chocolate').future);
+
+      expect(results.length, equals(2));
+      expect(results.every((r) => r.title.contains('Chocolate')), isTrue);
+    });
+
+    test('should return empty list when no matches', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+      await repository.addRecipe(Recipe()
+        ..title = 'Apple Pie'
+        ..ingredients = []
+        ..instructions = []);
+
+      final results =
+          await container.read(recipeSearchProvider('Chocolate').future);
+
+      expect(results, isEmpty);
+    });
+
+    test('should be case-insensitive', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+      await repository.addRecipe(Recipe()
+        ..title = 'CHOCOLATE CAKE'
+        ..ingredients = []
+        ..instructions = []);
+      await repository.addRecipe(Recipe()
+        ..title = 'chocolate mousse'
+        ..ingredients = []
+        ..instructions = []);
+
+      final results =
+          await container.read(recipeSearchProvider('ChOcOlAtE').future);
+
+      expect(results.length, equals(2));
+    });
+
+    test('should return all recipes for empty query', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+      await repository.addRecipe(Recipe()
+        ..title = 'Recipe 1'
+        ..ingredients = []
+        ..instructions = []);
+      await repository.addRecipe(Recipe()
+        ..title = 'Recipe 2'
+        ..ingredients = []
+        ..instructions = []);
+
+      final results = await container.read(recipeSearchProvider('').future);
+
+      expect(results.length, equals(2));
+    });
+
+    test('should trim whitespace from query', () async {
+      final container = ProviderContainer(
+        overrides: [
+          isarProvider.overrideWith((ref) async => testIsar),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(isarProvider.future);
+
+      final repository = container.read(recipeRepositoryProvider);
+      await repository.addRecipe(Recipe()
+        ..title = 'Chocolate Cake'
+        ..ingredients = []
+        ..instructions = []);
+
+      final results =
+          await container.read(recipeSearchProvider('  Chocolate  ').future);
+
+      expect(results.length, equals(1));
+      expect(results.first.title, equals('Chocolate Cake'));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Add `recipeSearchProvider` FutureProvider.family that accepts search query
- Calls repository's searchRecipes method
- Case-insensitive search
- Returns all recipes for empty query
- Add comprehensive unit tests (6 new tests)

## Test plan
- [x] Provider type test passes
- [x] Matching recipes test passes
- [x] Empty results test passes
- [x] Case-insensitive test passes
- [x] Empty query test passes
- [x] Whitespace trimming test passes

**Note:** This PR depends on PR #79 and is based on branch `feature/32-recipes-list-provider`.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)