### PR TITLE
#34 Create home screen scaffold with app bar

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'screens/home_screen.dart';
+
 /// The root widget of the Sodium recipe app.
 class SodiumApp extends StatelessWidget {
   const SodiumApp({super.key});
@@ -12,11 +14,7 @@ class SodiumApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
         useMaterial3: true,
       ),
-      home: const Scaffold(
-        body: Center(
-          child: Text('Sodium Recipe App'),
-        ),
-      ),
+      home: const HomeScreen(),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The main home screen displaying the list of recipes.
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('My Recipes'),
+      ),
+      body: const Center(
+        child: Text('Recipe list will appear here'),
+      ),
+    );
+  }
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/screens/home_screen.dart';
+
+void main() {
+  group('HomeScreen', () {
+    testWidgets('should display app bar with title', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      expect(find.text('My Recipes'), findsOneWidget);
+    });
+
+    testWidgets('should have a Scaffold', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      expect(find.byType(Scaffold), findsOneWidget);
+    });
+
+    testWidgets('should have an AppBar', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      expect(find.byType(AppBar), findsOneWidget);
+    });
+
+    testWidgets('should display placeholder text', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      expect(find.text('Recipe list will appear here'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create `HomeScreen` as ConsumerWidget in `lib/screens/home_screen.dart`
- Add Scaffold with AppBar titled "My Recipes"
- Placeholder body for recipe list content
- Update `app.dart` to use HomeScreen as home
- Add widget tests for screen components

## Test plan
- [x] App bar title test passes
- [x] Scaffold present test passes
- [x] AppBar present test passes
- [x] Placeholder text test passes

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)