### PR TITLE
#35 Create recipe card widget

### DIFF
--- a/lib/widgets/recipe_card.dart
+++ b/lib/widgets/recipe_card.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../models/recipe.dart';
+
+/// A card widget that displays a recipe preview.
+///
+/// Shows the recipe title and a preview of ingredients.
+/// The entire card is tappable and triggers the [onTap] callback.
+class RecipeCard extends StatelessWidget {
+  final Recipe recipe;
+  final VoidCallback? onTap;
+
+  const RecipeCard({
+    super.key,
+    required this.recipe,
+    this.onTap,
+  });
+
+  String _buildIngredientPreview() {
+    if (recipe.ingredients.isEmpty) {
+      return 'No ingredients';
+    }
+
+    final count = recipe.ingredients.length;
+    if (count == 1) {
+      return '1 ingredient';
+    }
+    return '$count ingredients';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                recipe.title,
+                style: Theme.of(context).textTheme.titleMedium,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                _buildIngredientPreview(),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/widgets/recipe_card_test.dart
+++ b/test/widgets/recipe_card_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/models/recipe.dart';
+import 'package:sodium/widgets/recipe_card.dart';
+
+void main() {
+  group('RecipeCard', () {
+    late Recipe recipe;
+
+    setUp(() {
+      recipe = Recipe()
+        ..id = 1
+        ..title = 'Test Recipe'
+        ..ingredients = ['flour', 'sugar', 'eggs']
+        ..instructions = ['mix', 'bake'];
+    });
+
+    testWidgets('should display recipe title', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(recipe: recipe),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Recipe'), findsOneWidget);
+    });
+
+    testWidgets('should display ingredient count', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(recipe: recipe),
+          ),
+        ),
+      );
+
+      expect(find.text('3 ingredients'), findsOneWidget);
+    });
+
+    testWidgets('should display singular ingredient for one item',
+        (tester) async {
+      recipe.ingredients = ['flour'];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(recipe: recipe),
+          ),
+        ),
+      );
+
+      expect(find.text('1 ingredient'), findsOneWidget);
+    });
+
+    testWidgets('should display no ingredients message when empty',
+        (tester) async {
+      recipe.ingredients = [];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(recipe: recipe),
+          ),
+        ),
+      );
+
+      expect(find.text('No ingredients'), findsOneWidget);
+    });
+
+    testWidgets('should trigger onTap callback when tapped', (tester) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(
+              recipe: recipe,
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(RecipeCard));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('should have a Card widget', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(recipe: recipe),
+          ),
+        ),
+      );
+
+      expect(find.byType(Card), findsOneWidget);
+    });
+
+    testWidgets('should have an InkWell for tap effect', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecipeCard(recipe: recipe),
+          ),
+        ),
+      );
+
+      expect(find.byType(InkWell), findsOneWidget);
+    });
+
+    testWidgets('should handle long titles with ellipsis', (tester) async {
+      recipe.title =
+          'This is a very long recipe title that should be truncated with ellipsis';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 200,
+              child: RecipeCard(recipe: recipe),
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.text(recipe.title));
+      expect(textWidget.maxLines, equals(2));
+      expect(textWidget.overflow, equals(TextOverflow.ellipsis));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create `RecipeCard` widget in `lib/widgets/recipe_card.dart`
- Displays recipe title with text overflow handling
- Shows ingredient count as subtitle
- Tappable card with InkWell effect
- Consistent styling using Theme

## Test plan
- [x] Display recipe title test passes
- [x] Display ingredient count test passes
- [x] Singular ingredient test passes
- [x] No ingredients message test passes
- [x] OnTap callback test passes
- [x] Card widget present test passes
- [x] InkWell present test passes
- [x] Long title ellipsis test passes

**Note:** This PR depends on PR #81 and is based on branch `feature/34-home-screen-scaffold`.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)