### PR TITLE
#36 Create recipe list view on home screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,18 +1,52 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../providers/recipe_provider.dart';
+import '../widgets/recipe_card.dart';
+
 /// The main home screen displaying the list of recipes.
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final recipesAsync = ref.watch(recipesProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Recipes'),
       ),
-      body: const Center(
-        child: Text('Recipe list will appear here'),
+      body: recipesAsync.when(
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stack) => Center(
+          child: Text('Error: $error'),
+        ),
+        data: (recipes) {
+          if (recipes.isEmpty) {
+            return const Center(
+              child: Text('No recipes yet. Add your first recipe!'),
+            );
+          }
+
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: recipes.length,
+            itemBuilder: (context, index) {
+              final recipe = recipes[index];
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: RecipeCard(
+                  recipe: recipe,
+                  onTap: () {
+                    // TODO: Navigate to recipe detail screen
+                  },
+                ),
+              );
+            },
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Connect HomeScreen to `recipesProvider`
- Implement ListView.builder with RecipeCard widgets
- Handle AsyncValue states: loading, error, data
- Display empty state message when no recipes exist
- Add TODO for navigation to detail screen (detail screen not yet implemented)

## Test plan
- [x] App bar title test passes
- [x] Scaffold present test passes
- [x] AppBar present test passes
- [x] Loading indicator test passes
- [x] Empty state test passes
- [x] Recipe cards display test passes
- [x] Error message test passes
- [x] ListView present test passes

**Note:** This PR depends on PR #82 and is based on branch `feature/35-recipe-card-widget`.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)