### PR TITLE
#34 Fix widget_test.dart to work with HomeScreen providers

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,11 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:sodium/app.dart';
+import 'package:sodium/models/recipe.dart';
+import 'package:sodium/providers/recipe_provider.dart';
 
 void main() {
   testWidgets('App renders correctly', (WidgetTester tester) async {
-    await tester.pumpWidget(const SodiumApp());
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recipesProvider.overrideWith((ref) async => <Recipe>[]),
+        ],
+        child: const SodiumApp(),
+      ),
+    );
 
-    expect(find.text('Sodium Recipe App'), findsOneWidget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('My Recipes'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Fix widget_test.dart that broke after HomeScreen was integrated with Riverpod providers
- Wrap SodiumApp in ProviderScope with recipesProvider override
- Update expected text from 'Sodium Recipe App' to 'My Recipes'

## Test plan
- [x] Widget test passes locally
- [x] No analysis issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)