### PR TITLE
#37 Add floating action button to home screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -16,6 +16,12 @@ class HomeScreen extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('My Recipes'),
       ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // TODO: Navigate to recipe edit screen (create mode)
+        },
+        child: const Icon(Icons.add),
+      ),
       body: recipesAsync.when(
         loading: () => const Center(
           child: CircularProgressIndicator(),

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -178,5 +178,61 @@ void main() {
 
       expect(find.byType(ListView), findsOneWidget);
     });
+
+    testWidgets('should have a FloatingActionButton', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            recipesProvider.overrideWith((ref) async => <Recipe>[]),
+          ],
+          child: const MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('FAB should have add icon', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            recipesProvider.overrideWith((ref) async => <Recipe>[]),
+          ],
+          child: const MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+
+    testWidgets('FAB should be tappable', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            recipesProvider.overrideWith((ref) async => <Recipe>[]),
+          ],
+          child: const MaterialApp(
+            home: HomeScreen(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // FAB should be tappable without error
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      // FAB should still be visible after tap
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Add FloatingActionButton to HomeScreen Scaffold
- FAB uses plus icon (Icons.add)
- FAB is positioned using standard Material positioning
- Navigation to RecipeEditScreen deferred (TODO) until screen is implemented

## Test plan
- [x] FAB is present on home screen
- [x] FAB has add icon
- [x] FAB is tappable without error

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)