### PR TITLE
#38 Create empty state widget for no recipes

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/recipe_provider.dart';
+import '../widgets/empty_state.dart';
 import '../widgets/recipe_card.dart';
 
 /// The main home screen displaying the list of recipes.
@@ -31,8 +32,10 @@ class HomeScreen extends ConsumerWidget {
         ),
         data: (recipes) {
           if (recipes.isEmpty) {
-            return const Center(
-              child: Text('No recipes yet. Add your first recipe!'),
+            return const EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'No recipes yet',
+              secondaryMessage: 'Tap + to add your first recipe',
             );
           }
 

--- a/lib/widgets/empty_state.dart
+++ b/lib/widgets/empty_state.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// A widget that displays an empty state with an icon and message.
+///
+/// Used when there is no content to display, such as when
+/// the recipe list is empty.
+class EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String primaryMessage;
+  final String? secondaryMessage;
+
+  const EmptyState({
+    super.key,
+    required this.icon,
+    required this.primaryMessage,
+    this.secondaryMessage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 64,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              primaryMessage,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            if (secondaryMessage != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                secondaryMessage!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sodium/models/recipe.dart';
 import 'package:sodium/providers/recipe_provider.dart';
 import 'package:sodium/screens/home_screen.dart';
+import 'package:sodium/widgets/empty_state.dart';
 import 'package:sodium/widgets/recipe_card.dart';
 
 void main() {
@@ -96,10 +97,9 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(
-        find.text('No recipes yet. Add your first recipe!'),
-        findsOneWidget,
-      );
+      expect(find.byType(EmptyState), findsOneWidget);
+      expect(find.text('No recipes yet'), findsOneWidget);
+      expect(find.text('Tap + to add your first recipe'), findsOneWidget);
     });
 
     testWidgets('should display recipe cards when recipes exist',

--- a/test/widgets/empty_state_test.dart
+++ b/test/widgets/empty_state_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/widgets/empty_state.dart';
+
+void main() {
+  group('EmptyState', () {
+    testWidgets('should display icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'Test message',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.restaurant_menu), findsOneWidget);
+    });
+
+    testWidgets('should display primary message', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'No recipes yet',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('No recipes yet'), findsOneWidget);
+    });
+
+    testWidgets('should display secondary message when provided',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'No recipes yet',
+              secondaryMessage: 'Tap + to add your first recipe',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Tap + to add your first recipe'), findsOneWidget);
+    });
+
+    testWidgets('should not display secondary message when not provided',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'No recipes yet',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Tap + to add your first recipe'), findsNothing);
+    });
+
+    testWidgets('content should be vertically centered', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'Test message',
+            ),
+          ),
+        ),
+      );
+
+      // Find the Column inside EmptyState and verify it has mainAxisAlignment center
+      final column = tester.widget<Column>(
+        find.descendant(
+            of: find.byType(EmptyState), matching: find.byType(Column)),
+      );
+      expect(column.mainAxisAlignment, MainAxisAlignment.center);
+    });
+
+    testWidgets('should have Column for layout', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'Test message',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Column), findsOneWidget);
+    });
+
+    testWidgets('icon should have correct size', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyState(
+              icon: Icons.restaurant_menu,
+              primaryMessage: 'Test message',
+            ),
+          ),
+        ),
+      );
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.restaurant_menu));
+      expect(icon.size, equals(64));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create reusable `EmptyState` widget in `lib/widgets/empty_state.dart`
- Widget displays an icon, primary message, and optional secondary message
- Integrate EmptyState into HomeScreen for empty recipe list
- Uses restaurant_menu icon with "No recipes yet" and "Tap + to add your first recipe" messages

## Test plan
- [x] EmptyState displays icon correctly
- [x] EmptyState displays primary message
- [x] EmptyState displays secondary message when provided
- [x] EmptyState hides secondary message when not provided
- [x] Content is vertically centered
- [x] Icon has correct size (64)
- [x] HomeScreen uses EmptyState when no recipes

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)