### PR TITLE
#39 Create loading state widget

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/recipe_provider.dart';
 import '../widgets/empty_state.dart';
+import '../widgets/loading_widget.dart';
 import '../widgets/recipe_card.dart';
 
 /// The main home screen displaying the list of recipes.
@@ -24,9 +25,7 @@ class HomeScreen extends ConsumerWidget {
         child: const Icon(Icons.add),
       ),
       body: recipesAsync.when(
-        loading: () => const Center(
-          child: CircularProgressIndicator(),
-        ),
+        loading: () => const LoadingWidget(),
         error: (error, stack) => Center(
           child: Text('Error: $error'),
         ),

--- a/lib/widgets/loading_widget.dart
+++ b/lib/widgets/loading_widget.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// A widget that displays a centered loading indicator.
+///
+/// Used during async operations to provide visual feedback
+/// that the app is working.
+class LoadingWidget extends StatelessWidget {
+  final String? message;
+
+  const LoadingWidget({
+    super.key,
+    this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          if (message != null) ...[
+            const SizedBox(height: 16),
+            Text(
+              message!,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:sodium/models/recipe.dart';
 import 'package:sodium/providers/recipe_provider.dart';
 import 'package:sodium/screens/home_screen.dart';
 import 'package:sodium/widgets/empty_state.dart';
+import 'package:sodium/widgets/loading_widget.dart';
 import 'package:sodium/widgets/recipe_card.dart';
 
 void main() {
@@ -77,6 +78,7 @@ void main() {
       );
 
       // Initial pump shows loading state before async completes
+      expect(find.byType(LoadingWidget), findsOneWidget);
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
       // Now let it settle to complete

--- a/test/widgets/loading_widget_test.dart
+++ b/test/widgets/loading_widget_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/widgets/loading_widget.dart';
+
+void main() {
+  group('LoadingWidget', () {
+    testWidgets('should display CircularProgressIndicator', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingWidget(),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('should be centered', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingWidget(),
+          ),
+        ),
+      );
+
+      // LoadingWidget wraps content in a Center widget
+      expect(
+        find.descendant(
+            of: find.byType(LoadingWidget), matching: find.byType(Center)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('should display message when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingWidget(message: 'Loading recipes...'),
+          ),
+        ),
+      );
+
+      expect(find.text('Loading recipes...'), findsOneWidget);
+    });
+
+    testWidgets('should not display message when not provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingWidget(),
+          ),
+        ),
+      );
+
+      // No text widgets other than from the spinner
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('should have Column for layout', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingWidget(),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+            of: find.byType(LoadingWidget), matching: find.byType(Column)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('content should be vertically centered', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingWidget(),
+          ),
+        ),
+      );
+
+      final column = tester.widget<Column>(
+        find.descendant(
+            of: find.byType(LoadingWidget), matching: find.byType(Column)),
+      );
+      expect(column.mainAxisAlignment, MainAxisAlignment.center);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create reusable `LoadingWidget` in `lib/widgets/loading_widget.dart`
- Widget displays centered CircularProgressIndicator
- Supports optional loading message
- Integrate LoadingWidget into HomeScreen for async loading state

## Test plan
- [x] LoadingWidget displays CircularProgressIndicator
- [x] Content is centered
- [x] Message displays when provided
- [x] Message hidden when not provided
- [x] Has Column for layout
- [x] Content vertically centered
- [x] HomeScreen uses LoadingWidget during loading

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)