### PR TITLE
#40 Create recipe edit screen scaffold

### DIFF
--- a/lib/screens/recipe_edit_screen.dart
+++ b/lib/screens/recipe_edit_screen.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Screen for creating or editing a recipe.
+///
+/// When [recipeId] is null, the screen is in create mode.
+/// When [recipeId] is provided, the screen is in edit mode.
+class RecipeEditScreen extends ConsumerStatefulWidget {
+  final int? recipeId;
+
+  const RecipeEditScreen({
+    super.key,
+    this.recipeId,
+  });
+
+  @override
+  ConsumerState<RecipeEditScreen> createState() => _RecipeEditScreenState();
+}
+
+class _RecipeEditScreenState extends ConsumerState<RecipeEditScreen> {
+  bool get isEditMode => widget.recipeId != null;
+
+  void _onSave() {
+    // TODO: Implement save functionality
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditMode ? 'Edit Recipe' : 'New Recipe'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.check),
+            onPressed: _onSave,
+          ),
+        ],
+      ),
+      body: const SingleChildScrollView(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // TODO: Add form fields
+            Center(
+              child: Text('Recipe form will go here'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/screens/recipe_edit_screen_test.dart
+++ b/test/screens/recipe_edit_screen_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/screens/recipe_edit_screen.dart';
+
+void main() {
+  group('RecipeEditScreen', () {
+    group('Create mode (no recipeId)', () {
+      testWidgets('should display "New Recipe" in AppBar', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.text('New Recipe'), findsOneWidget);
+      });
+
+      testWidgets('should have a Scaffold', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.byType(Scaffold), findsOneWidget);
+      });
+
+      testWidgets('should have an AppBar', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.byType(AppBar), findsOneWidget);
+      });
+
+      testWidgets('should have a save button in AppBar', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+      });
+
+      testWidgets('save button should be tappable', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byIcon(Icons.check));
+        await tester.pumpAndSettle();
+
+        // Should not throw error
+        expect(find.byType(RecipeEditScreen), findsOneWidget);
+      });
+
+      testWidgets('should have scrollable body', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.byType(SingleChildScrollView), findsOneWidget);
+      });
+    });
+
+    group('Edit mode (with recipeId)', () {
+      testWidgets('should display "Edit Recipe" in AppBar', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        expect(find.text('Edit Recipe'), findsOneWidget);
+      });
+
+      testWidgets('should have save button in edit mode', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+      });
+    });
+
+    testWidgets('should support back navigation', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const RecipeEditScreen(),
+                      ),
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Navigate to RecipeEditScreen
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New Recipe'), findsOneWidget);
+
+      // Tap back button
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      // Should be back on original screen
+      expect(find.text('Open'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Create `RecipeEditScreen` in `lib/screens/recipe_edit_screen.dart`
- Implemented as ConsumerStatefulWidget
- Accepts optional `recipeId` parameter for edit mode
- Dynamic AppBar title: "New Recipe" (create) / "Edit Recipe" (edit)
- Save action button in AppBar
- Scrollable body with SingleChildScrollView

## Test plan
- [x] Create mode shows "New Recipe" title
- [x] Edit mode shows "Edit Recipe" title
- [x] Scaffold present
- [x] AppBar present
- [x] Save button present and tappable
- [x] Scrollable body present
- [x] Back navigation works

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)