### PR TITLE
#41 Create recipe title input field

### DIFF
--- a/lib/screens/recipe_edit_screen.dart
+++ b/lib/screens/recipe_edit_screen.dart
@@ -18,10 +18,28 @@ class RecipeEditScreen extends ConsumerStatefulWidget {
 }
 
 class _RecipeEditScreenState extends ConsumerState<RecipeEditScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+
   bool get isEditMode => widget.recipeId != null;
 
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
   void _onSave() {
-    // TODO: Implement save functionality
+    if (_formKey.currentState!.validate()) {
+      // TODO: Implement save functionality
+    }
+  }
+
+  String? _validateTitle(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return 'Please enter a recipe title';
+    }
+    return null;
   }
 
   @override
@@ -36,16 +54,26 @@ class _RecipeEditScreenState extends ConsumerState<RecipeEditScreen> {
           ),
         ],
       ),
-      body: const SingleChildScrollView(
-        padding: EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // TODO: Add form fields
-            Center(
-              child: Text('Recipe form will go here'),
-            ),
-          ],
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Recipe Title',
+                  hintText: 'Enter recipe name',
+                  border: OutlineInputBorder(),
+                ),
+                validator: _validateTitle,
+                textInputAction: TextInputAction.next,
+              ),
+              // TODO: Add more form fields
+            ],
+          ),
         ),
       ),
     );

--- a/test/screens/recipe_edit_screen_test.dart
+++ b/test/screens/recipe_edit_screen_test.dart
@@ -109,6 +109,109 @@ void main() {
       });
     });
 
+    group('Title input field', () {
+      testWidgets('should have a title text field', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextFormField), findsOneWidget);
+      });
+
+      testWidgets('should have label text', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.text('Recipe Title'), findsOneWidget);
+      });
+
+      testWidgets('should have hint text', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.text('Enter recipe name'), findsOneWidget);
+      });
+
+      testWidgets('should accept text input', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextFormField), 'My Recipe');
+        await tester.pump();
+
+        expect(find.text('My Recipe'), findsOneWidget);
+      });
+
+      testWidgets('should show validation error when empty on save',
+          (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        // Tap save without entering title
+        await tester.tap(find.byIcon(Icons.check));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Please enter a recipe title'), findsOneWidget);
+      });
+
+      testWidgets('should not show error when title is entered',
+          (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        // Enter title
+        await tester.enterText(find.byType(TextFormField), 'Valid Title');
+        await tester.pump();
+
+        // Tap save
+        await tester.tap(find.byIcon(Icons.check));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Please enter a recipe title'), findsNothing);
+      });
+
+      testWidgets('should have Form widget', (tester) async {
+        await tester.pumpWidget(
+          const ProviderScope(
+            child: MaterialApp(
+              home: RecipeEditScreen(),
+            ),
+          ),
+        );
+
+        expect(find.byType(Form), findsOneWidget);
+      });
+    });
+
     testWidgets('should support back navigation', (tester) async {
       await tester.pumpWidget(
         ProviderScope(


### PR DESCRIPTION
## Summary
- Add Form widget with GlobalKey for validation
- Add TextFormField for recipe title with validation
- Title field has label "Recipe Title" and hint "Enter recipe name"
- Required field validation shows error "Please enter a recipe title"
- Add TextEditingController with proper disposal

## Test plan
- [x] Title text field is present
- [x] Has correct label text
- [x] Has correct hint text
- [x] Accepts text input
- [x] Shows validation error when empty on save
- [x] No error when title is entered
- [x] Form widget present

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)