### PR TITLE
#43 Create dynamic instructions list input widget

### DIFF
--- a/lib/widgets/instructions_input.dart
+++ b/lib/widgets/instructions_input.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+/// A dynamic input widget for managing a list of recipe instructions.
+///
+/// Allows users to add, remove, and edit instruction steps.
+/// Steps are automatically numbered (1, 2, 3...).
+/// At least one instruction field is always visible.
+class InstructionsInput extends StatefulWidget {
+  /// Initial list of instructions to populate the fields.
+  final List<String> initialInstructions;
+
+  /// Callback fired whenever the instructions list changes.
+  final ValueChanged<List<String>> onChange;
+
+  const InstructionsInput({
+    super.key,
+    this.initialInstructions = const [],
+    required this.onChange,
+  });
+
+  @override
+  State<InstructionsInput> createState() => _InstructionsInputState();
+}
+
+class _InstructionsInputState extends State<InstructionsInput> {
+  final List<TextEditingController> _controllers = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeControllers();
+  }
+
+  void _initializeControllers() {
+    // Initialize with existing instructions or one empty field
+    if (widget.initialInstructions.isEmpty) {
+      _controllers.add(TextEditingController());
+    } else {
+      for (final instruction in widget.initialInstructions) {
+        _controllers.add(TextEditingController(text: instruction));
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _notifyChange() {
+    final instructions = _controllers
+        .map((c) => c.text)
+        .where((text) => text.isNotEmpty)
+        .toList();
+    widget.onChange(instructions);
+  }
+
+  void _addStep() {
+    setState(() {
+      _controllers.add(TextEditingController());
+    });
+    _notifyChange();
+  }
+
+  void _removeStep(int index) {
+    // Don't allow removing the last instruction
+    if (_controllers.length <= 1) return;
+
+    setState(() {
+      _controllers[index].dispose();
+      _controllers.removeAt(index);
+    });
+    _notifyChange();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Instructions',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        ...List.generate(_controllers.length, (index) {
+          final stepNumber = index + 1;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  margin: const EdgeInsets.only(right: 8, top: 8),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '$stepNumber',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: TextFormField(
+                    controller: _controllers[index],
+                    decoration: InputDecoration(
+                      hintText: 'Describe this step...',
+                      border: const OutlineInputBorder(),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 12,
+                      ),
+                      suffixIcon: _controllers.length > 1
+                          ? IconButton(
+                              icon: const Icon(Icons.close),
+                              onPressed: () => _removeStep(index),
+                              tooltip: 'Remove step',
+                            )
+                          : null,
+                    ),
+                    onChanged: (_) => _notifyChange(),
+                    maxLines: 3,
+                    minLines: 1,
+                    textInputAction: TextInputAction.newline,
+                    keyboardType: TextInputType.multiline,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+        const SizedBox(height: 8),
+        OutlinedButton.icon(
+          onPressed: _addStep,
+          icon: const Icon(Icons.add),
+          label: const Text('Add Step'),
+        ),
+      ],
+    );
+  }
+}

--- a/test/widgets/instructions_input_test.dart
+++ b/test/widgets/instructions_input_test.dart
@@ -1,0 +1,513 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/widgets/instructions_input.dart';
+
+void main() {
+  group('InstructionsInput', () {
+    group('Initial state', () {
+      testWidgets('should display one empty text field by default',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextFormField), findsOneWidget);
+      });
+
+      testWidgets('should display "Instructions" label', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Instructions'), findsOneWidget);
+      });
+
+      testWidgets('should display hint text', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Describe this step...'), findsOneWidget);
+      });
+
+      testWidgets('should display Add Step button', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Add Step'), findsOneWidget);
+        expect(find.byIcon(Icons.add), findsOneWidget);
+      });
+
+      testWidgets('should display step number 1', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('1'), findsOneWidget);
+      });
+
+      testWidgets('should not show remove button when only one field',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.close), findsNothing);
+      });
+    });
+
+    group('Initial instructions', () {
+      testWidgets('should populate fields with initial instructions',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const [
+                  'Preheat oven',
+                  'Mix ingredients',
+                  'Bake for 30 minutes'
+                ],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextFormField), findsNWidgets(3));
+        expect(find.text('Preheat oven'), findsOneWidget);
+        expect(find.text('Mix ingredients'), findsOneWidget);
+        expect(find.text('Bake for 30 minutes'), findsOneWidget);
+      });
+
+      testWidgets('should display correct step numbers', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['Step 1', 'Step 2', 'Step 3'],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('1'), findsOneWidget);
+        expect(find.text('2'), findsOneWidget);
+        expect(find.text('3'), findsOneWidget);
+      });
+
+      testWidgets(
+          'should show remove buttons when multiple initial instructions',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['Step 1', 'Step 2'],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.close), findsNWidgets(2));
+      });
+    });
+
+    group('Adding steps', () {
+      testWidgets('should add new text field when Add button is pressed',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextFormField), findsOneWidget);
+
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+
+        expect(find.byType(TextFormField), findsNWidgets(2));
+      });
+
+      testWidgets('should display correct step numbers after adding',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+
+        expect(find.text('1'), findsOneWidget);
+        expect(find.text('2'), findsOneWidget);
+        expect(find.text('3'), findsOneWidget);
+      });
+
+      testWidgets('should show remove buttons after adding second field',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.close), findsNothing);
+
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+
+        expect(find.byIcon(Icons.close), findsNWidgets(2));
+      });
+
+      testWidgets('should call onChange when adding step', (tester) async {
+        var callCount = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) => callCount++,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+
+        expect(callCount, 1);
+      });
+    });
+
+    group('Removing steps', () {
+      testWidgets('should remove text field when X button is pressed',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['Step 1', 'Step 2'],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextFormField), findsNWidgets(2));
+
+        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.pump();
+
+        expect(find.byType(TextFormField), findsOneWidget);
+      });
+
+      testWidgets('should renumber steps after removing', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['First', 'Second', 'Third'],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        // Remove the first step
+        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.pump();
+
+        // Should now have steps numbered 1 and 2
+        expect(find.text('1'), findsOneWidget);
+        expect(find.text('2'), findsOneWidget);
+        expect(find.text('3'), findsNothing);
+      });
+
+      testWidgets('should hide remove buttons when down to one field',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['Step 1', 'Step 2'],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.close), findsNWidgets(2));
+
+        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.pump();
+
+        expect(find.byIcon(Icons.close), findsNothing);
+      });
+
+      testWidgets('should call onChange when removing step', (tester) async {
+        List<String> lastInstructions = [];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['Step 1', 'Step 2'],
+                onChange: (instructions) => lastInstructions = instructions,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.pump();
+
+        expect(lastInstructions, ['Step 2']);
+      });
+
+      testWidgets('should remove correct step', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const ['First', 'Second', 'Third'],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        // Remove the second step
+        await tester.tap(find.byIcon(Icons.close).at(1));
+        await tester.pump();
+
+        expect(find.text('First'), findsOneWidget);
+        expect(find.text('Second'), findsNothing);
+        expect(find.text('Third'), findsOneWidget);
+      });
+    });
+
+    group('Text input', () {
+      testWidgets('should accept text input', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(
+            find.byType(TextFormField), 'Preheat oven to 350°F');
+        await tester.pump();
+
+        expect(find.text('Preheat oven to 350°F'), findsOneWidget);
+      });
+
+      testWidgets('should call onChange when text is entered', (tester) async {
+        List<String> lastInstructions = [];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (instructions) => lastInstructions = instructions,
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextFormField), 'Mix the batter');
+        await tester.pump();
+
+        expect(lastInstructions, ['Mix the batter']);
+      });
+
+      testWidgets('should filter out empty instructions in onChange',
+          (tester) async {
+        List<String> lastInstructions = [];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (instructions) => lastInstructions = instructions,
+              ),
+            ),
+          ),
+        );
+
+        // Add another step (now we have 2)
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+
+        // Enter text only in first field
+        await tester.enterText(find.byType(TextFormField).first, 'Step one');
+        await tester.pump();
+
+        // onChange should only contain 'Step one', not the empty second field
+        expect(lastInstructions, ['Step one']);
+      });
+    });
+
+    group('Multi-line support', () {
+      testWidgets('should support multi-line text entry', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        // Enter multi-line text
+        await tester.enterText(
+          find.byType(TextFormField),
+          'Line 1\nLine 2\nLine 3',
+        );
+        await tester.pump();
+
+        expect(find.text('Line 1\nLine 2\nLine 3'), findsOneWidget);
+      });
+
+      testWidgets('should expand for longer text', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                initialInstructions: const [
+                  'This is a longer instruction that might need more space to display properly in the text field'
+                ],
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        // Text should be visible
+        expect(
+          find.textContaining('This is a longer instruction'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('Layout', () {
+      testWidgets('should have Column as root widget', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          find.descendant(
+            of: find.byType(InstructionsInput),
+            matching: find.byType(Column),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('Add button should be tappable', (tester) async {
+        var tapped = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) => tapped = true,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Add Step'));
+        await tester.pump();
+
+        expect(tapped, isTrue);
+      });
+
+      testWidgets('should display step number in circle', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: InstructionsInput(
+                onChange: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        // Find the Container with BoxDecoration (circle)
+        final container = find.byWidgetPredicate((widget) {
+          if (widget is Container && widget.decoration != null) {
+            final decoration = widget.decoration as BoxDecoration?;
+            return decoration?.shape == BoxShape.circle;
+          }
+          return false;
+        });
+
+        expect(container, findsOneWidget);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `InstructionsInput` StatefulWidget for dynamic instruction step management
- Auto-numbered steps (1, 2, 3...) with circular step indicators
- Add "Add Step" button to append new steps
- Add remove button (X) on each row (only shown when multiple steps)
- Support multi-line text input with `maxLines: 3`
- Filter out empty instructions in onChange callback

## Technical Details
- **File:** `lib/widgets/instructions_input.dart`
- **Widget type:** StatefulWidget with TextEditingController list
- **Props:** `initialInstructions` (List<String>), `onChange` callback
- At least one instruction field always visible
- Hint text: "Describe this step..."
- Steps renumber automatically after removal

Closes #43

## Test plan
- [x] Widget displays one empty text field by default with step number 1
- [x] Widget populates fields with initial instructions
- [x] Steps are automatically numbered correctly
- [x] Can add new instruction steps
- [x] Can remove instruction steps (when more than one)
- [x] Steps renumber after removal
- [x] Remove buttons hidden when only one field
- [x] onChange callback fires on add/remove/edit
- [x] Empty instructions filtered from onChange output
- [x] Multi-line text entry supported
- [x] 26 widget tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)