### PR TITLE
#48 Add delete button with confirmation dialog

### DIFF
--- a/lib/screens/recipe_detail_screen.dart
+++ b/lib/screens/recipe_detail_screen.dart
@@ -115,6 +115,45 @@ class RecipeDetailScreen extends ConsumerWidget {
                 },
                 tooltip: 'Edit recipe',
               ),
+              IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Delete this recipe?'),
+                      content: const Text(
+                        'This action cannot be undone.',
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(true),
+                          style: TextButton.styleFrom(
+                            foregroundColor:
+                                Theme.of(context).colorScheme.error,
+                          ),
+                          child: const Text('Delete'),
+                        ),
+                      ],
+                    ),
+                  );
+
+                  if (confirmed == true) {
+                    final repository = ref.read(recipeRepositoryProvider);
+                    await repository.deleteRecipe(recipeId);
+                    // Refresh recipe list
+                    ref.invalidate(recipesProvider);
+                    if (context.mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  }
+                },
+                tooltip: 'Delete recipe',
+              ),
             ],
           ),
           body: SingleChildScrollView(

--- a/test/screens/recipe_detail_screen_test.dart
+++ b/test/screens/recipe_detail_screen_test.dart
@@ -580,6 +580,186 @@ void main() {
       });
     });
 
+    group('Delete button', () {
+      testWidgets('should display delete button in AppBar', (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) async {
+                return Recipe()
+                  ..id = 1
+                  ..title = 'Test Recipe'
+                  ..ingredients = []
+                  ..instructions = [];
+              }),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.delete), findsOneWidget);
+      });
+
+      testWidgets('should have delete button with tooltip', (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) async {
+                return Recipe()
+                  ..id = 1
+                  ..title = 'Test Recipe'
+                  ..ingredients = []
+                  ..instructions = [];
+              }),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final deleteButton = find.byIcon(Icons.delete);
+        expect(deleteButton, findsOneWidget);
+
+        // Find the IconButton that contains the delete icon
+        final iconButtons = find.byType(IconButton);
+        final deleteIconButton = tester.widget<IconButton>(iconButtons.at(1));
+        expect(deleteIconButton.tooltip, 'Delete recipe');
+      });
+
+      testWidgets('should show confirmation dialog when tapped',
+          (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) async {
+                return Recipe()
+                  ..id = 1
+                  ..title = 'Test Recipe'
+                  ..ingredients = []
+                  ..instructions = [];
+              }),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Tap delete button
+        await tester.tap(find.byIcon(Icons.delete));
+        await tester.pumpAndSettle();
+
+        // Should show confirmation dialog
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(find.text('Delete this recipe?'), findsOneWidget);
+        expect(find.text('This action cannot be undone.'), findsOneWidget);
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+      });
+
+      testWidgets('should dismiss dialog when Cancel is tapped',
+          (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) async {
+                return Recipe()
+                  ..id = 1
+                  ..title = 'Test Recipe'
+                  ..ingredients = []
+                  ..instructions = [];
+              }),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Tap delete button to show dialog
+        await tester.tap(find.byIcon(Icons.delete));
+        await tester.pumpAndSettle();
+
+        // Tap Cancel
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        // Dialog should be dismissed, still on detail screen
+        expect(find.byType(AlertDialog), findsNothing);
+        expect(find.text('Test Recipe'), findsOneWidget);
+      });
+
+      testWidgets('should not display delete button in loading state',
+          (tester) async {
+        final completer = Completer<Recipe?>();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) => completer.future),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        // In loading state, delete button should not be visible
+        expect(find.byIcon(Icons.delete), findsNothing);
+      });
+
+      testWidgets('should not display delete button in error state',
+          (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) async {
+                throw Exception('Error');
+              }),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // In error state, delete button should not be visible
+        expect(find.byIcon(Icons.delete), findsNothing);
+      });
+
+      testWidgets('should not display delete button when recipe not found',
+          (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              recipeByIdProvider(1).overrideWith((ref) async => null),
+            ],
+            child: const MaterialApp(
+              home: RecipeDetailScreen(recipeId: 1),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // When recipe not found, delete button should not be visible
+        expect(find.byIcon(Icons.delete), findsNothing);
+      });
+    });
+
     testWidgets('should have Scaffold', (tester) async {
       await tester.pumpWidget(
         ProviderScope(


### PR DESCRIPTION
## Summary
- Add delete IconButton to AppBar actions on recipe detail screen
- Show confirmation AlertDialog when delete button is tapped
- Delete recipe and navigate back on confirm, dismiss dialog on cancel
- Invalidate recipesProvider to refresh the recipe list after deletion

## Changes
- `lib/screens/recipe_detail_screen.dart`: Added delete button with confirmation dialog and delete logic
- `test/screens/recipe_detail_screen_test.dart`: Added 7 tests for delete button functionality

**Note:** This PR depends on #93 (Issue #46) and #94 (Issue #47). Please merge those first.

Closes #48

## Test plan
- [x] Delete button visible in AppBar when recipe is displayed
- [x] Delete button has correct tooltip
- [x] Tapping delete button shows confirmation dialog
- [x] Dialog shows correct text and buttons (Cancel, Delete)
- [x] Cancel button dismisses dialog without deleting
- [x] Delete button hidden in loading/error/not found states
- [x] All 32 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)