### PR TITLE
#49 Create search bar widget

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,10 @@ import '../providers/recipe_provider.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/loading_widget.dart';
 import '../widgets/recipe_card.dart';
+import '../widgets/search_bar.dart';
+
+/// Provider to track the current search query.
+final searchQueryProvider = StateProvider<String>((ref) => '');
 
 /// The main home screen displaying the list of recipes.
 class HomeScreen extends ConsumerWidget {
@@ -12,7 +16,10 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final recipesAsync = ref.watch(recipesProvider);
+    final searchQuery = ref.watch(searchQueryProvider);
+    final recipesAsync = searchQuery.isEmpty
+        ? ref.watch(recipesProvider)
+        : ref.watch(recipeSearchProvider(searchQuery));
 
     return Scaffold(
       appBar: AppBar(
@@ -24,37 +31,58 @@ class HomeScreen extends ConsumerWidget {
         },
         child: const Icon(Icons.add),
       ),
-      body: recipesAsync.when(
-        loading: () => const LoadingWidget(),
-        error: (error, stack) => Center(
-          child: Text('Error: $error'),
-        ),
-        data: (recipes) {
-          if (recipes.isEmpty) {
-            return const EmptyState(
-              icon: Icons.restaurant_menu,
-              primaryMessage: 'No recipes yet',
-              secondaryMessage: 'Tap + to add your first recipe',
-            );
-          }
-
-          return ListView.builder(
+      body: Column(
+        children: [
+          Padding(
             padding: const EdgeInsets.all(16),
-            itemCount: recipes.length,
-            itemBuilder: (context, index) {
-              final recipe = recipes[index];
-              return Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: RecipeCard(
-                  recipe: recipe,
-                  onTap: () {
-                    // TODO: Navigate to recipe detail screen
+            child: RecipeSearchBar(
+              onSearch: (query) {
+                ref.read(searchQueryProvider.notifier).state = query;
+              },
+            ),
+          ),
+          Expanded(
+            child: recipesAsync.when(
+              loading: () => const LoadingWidget(),
+              error: (error, stack) => Center(
+                child: Text('Error: $error'),
+              ),
+              data: (recipes) {
+                if (recipes.isEmpty) {
+                  if (searchQuery.isNotEmpty) {
+                    return const EmptyState(
+                      icon: Icons.search_off,
+                      primaryMessage: 'No recipes found',
+                      secondaryMessage: 'Try a different search term',
+                    );
+                  }
+                  return const EmptyState(
+                    icon: Icons.restaurant_menu,
+                    primaryMessage: 'No recipes yet',
+                    secondaryMessage: 'Tap + to add your first recipe',
+                  );
+                }
+
+                return ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: recipes.length,
+                  itemBuilder: (context, index) {
+                    final recipe = recipes[index];
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: RecipeCard(
+                        recipe: recipe,
+                        onTap: () {
+                          // TODO: Navigate to recipe detail screen
+                        },
+                      ),
+                    );
                   },
-                ),
-              );
-            },
-          );
-        },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/search_bar.dart
+++ b/lib/widgets/search_bar.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// A search bar widget with debounced input.
+///
+/// Provides a text field with a search icon and clear button.
+/// The [onSearch] callback is debounced to prevent excessive calls.
+class RecipeSearchBar extends StatefulWidget {
+  /// Callback fired when the search query changes (debounced).
+  final ValueChanged<String> onSearch;
+
+  /// Debounce duration in milliseconds. Defaults to 300ms.
+  final int debounceDuration;
+
+  const RecipeSearchBar({
+    super.key,
+    required this.onSearch,
+    this.debounceDuration = 300,
+  });
+
+  @override
+  State<RecipeSearchBar> createState() => _RecipeSearchBarState();
+}
+
+class _RecipeSearchBarState extends State<RecipeSearchBar> {
+  final _controller = TextEditingController();
+  Timer? _debounceTimer;
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onTextChanged(String value) {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(
+      Duration(milliseconds: widget.debounceDuration),
+      () {
+        widget.onSearch(value);
+      },
+    );
+  }
+
+  void _onClear() {
+    _controller.clear();
+    _debounceTimer?.cancel();
+    widget.onSearch('');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _controller,
+      onChanged: _onTextChanged,
+      decoration: InputDecoration(
+        hintText: 'Search recipes...',
+        prefixIcon: const Icon(Icons.search),
+        suffixIcon: ListenableBuilder(
+          listenable: _controller,
+          builder: (context, _) {
+            if (_controller.text.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            return IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: _onClear,
+              tooltip: 'Clear search',
+            );
+          },
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+      ),
+    );
+  }
+}

--- a/test/widgets/search_bar_test.dart
+++ b/test/widgets/search_bar_test.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sodium/widgets/search_bar.dart';
+
+void main() {
+  group('RecipeSearchBar', () {
+    group('Initial state', () {
+      testWidgets('should display TextField', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextField), findsOneWidget);
+      });
+
+      testWidgets('should display search icon', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.search), findsOneWidget);
+      });
+
+      testWidgets('should display hint text', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Search recipes...'), findsOneWidget);
+      });
+
+      testWidgets('should not display clear button when empty', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.clear), findsNothing);
+      });
+    });
+
+    group('Text input', () {
+      testWidgets('should accept text input', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'pasta');
+        await tester.pump();
+
+        expect(find.text('pasta'), findsOneWidget);
+      });
+
+      testWidgets('should show clear button when text is entered',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.clear), findsNothing);
+
+        await tester.enterText(find.byType(TextField), 'pasta');
+        await tester.pump();
+
+        expect(find.byIcon(Icons.clear), findsOneWidget);
+      });
+    });
+
+    group('Clear button', () {
+      testWidgets('should clear text when clear button is tapped',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'pasta');
+        await tester.pump();
+
+        expect(find.text('pasta'), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.clear));
+        await tester.pump();
+
+        expect(find.text('pasta'), findsNothing);
+      });
+
+      testWidgets('should hide clear button after clearing', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'pasta');
+        await tester.pump();
+
+        expect(find.byIcon(Icons.clear), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.clear));
+        await tester.pump();
+
+        expect(find.byIcon(Icons.clear), findsNothing);
+      });
+
+      testWidgets('should call onSearch with empty string when cleared',
+          (tester) async {
+        String? lastQuery;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (query) => lastQuery = query,
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'pasta');
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.clear));
+        await tester.pump();
+
+        expect(lastQuery, '');
+      });
+    });
+
+    group('Debounce', () {
+      testWidgets('should debounce onSearch calls', (tester) async {
+        final searchCalls = <String>[];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (query) => searchCalls.add(query),
+                debounceDuration: 300,
+              ),
+            ),
+          ),
+        );
+
+        // Type rapidly
+        await tester.enterText(find.byType(TextField), 'p');
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.enterText(find.byType(TextField), 'pa');
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.enterText(find.byType(TextField), 'pas');
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.enterText(find.byType(TextField), 'past');
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.enterText(find.byType(TextField), 'pasta');
+        await tester.pump();
+
+        // Before debounce completes, no calls should have been made
+        expect(searchCalls, isEmpty);
+
+        // Wait for debounce to complete
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // Only the final value should be sent
+        expect(searchCalls, ['pasta']);
+      });
+
+      testWidgets('should call onSearch after debounce delay', (tester) async {
+        String? lastQuery;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (query) => lastQuery = query,
+                debounceDuration: 300,
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'chicken');
+        await tester.pump();
+
+        // Not yet called
+        expect(lastQuery, isNull);
+
+        // Wait for debounce
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(lastQuery, 'chicken');
+      });
+
+      testWidgets('should cancel previous debounce on new input',
+          (tester) async {
+        final searchCalls = <String>[];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (query) => searchCalls.add(query),
+                debounceDuration: 300,
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'first');
+        await tester.pump(const Duration(milliseconds: 200));
+
+        // Enter new text before debounce completes
+        await tester.enterText(find.byType(TextField), 'second');
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // Only 'second' should be called, 'first' was cancelled
+        expect(searchCalls, ['second']);
+      });
+    });
+
+    group('Layout', () {
+      testWidgets('should have OutlineInputBorder', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        final textField = tester.widget<TextField>(find.byType(TextField));
+        final decoration = textField.decoration!;
+        expect(decoration.border, isA<OutlineInputBorder>());
+      });
+
+      testWidgets('clear button should have tooltip', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: RecipeSearchBar(
+                onSearch: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'test');
+        await tester.pump();
+
+        final iconButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.clear),
+        );
+        expect(iconButton.tooltip, 'Clear search');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Created `RecipeSearchBar` widget with debounced text input (300ms default)
- Search bar displays a TextField with search icon prefix
- Clear button appears when text is entered
- Integrated search bar into `HomeScreen` with search state management
- Added `searchQueryProvider` to track the current search query
- Home screen now displays different empty states for "no recipes" vs "no search results"

## Changes
- **New file**: `lib/widgets/search_bar.dart` - RecipeSearchBar StatefulWidget
- **New file**: `test/widgets/search_bar_test.dart` - 14 comprehensive tests
- **Modified**: `lib/screens/home_screen.dart` - Integrated search functionality

## Test Coverage
- 14 new tests covering:
  - Initial state (TextField, search icon, hint text, no clear button)
  - Text input (accepts input, shows clear button)
  - Clear button (clears text, hides button, calls onSearch with empty string)
  - Debounce behavior (debounces calls, respects delay, cancels on new input)
  - Layout (OutlineInputBorder, clear button tooltip)

## Test Plan
- [x] All 145 tests pass
- [x] `flutter analyze` passes with no issues
- [x] Code formatted with `dart format`

Closes #49