### PR TITLE
#53 Fix database isolation in Isar tests

### DIFF
--- a/test/providers/database_provider_test.dart
+++ b/test/providers/database_provider_test.dart
@@ -12,6 +12,7 @@ void main() {
     testIsar = await Isar.open(
       [RecipeSchema],
       directory: '',
+      name: 'database_provider_test',
     );
   });
 

--- a/test/providers/recipe_provider_test.dart
+++ b/test/providers/recipe_provider_test.dart
@@ -14,6 +14,7 @@ void main() {
     testIsar = await Isar.open(
       [RecipeSchema],
       directory: '',
+      name: 'recipe_provider_test',
     );
   });
 

--- a/test/repositories/recipe_repository_test.dart
+++ b/test/repositories/recipe_repository_test.dart
@@ -12,6 +12,7 @@ void main() {
     isar = await Isar.open(
       [RecipeSchema],
       directory: '',
+      name: 'recipe_repository_test',
     );
     repository = RecipeRepository(isar);
   });


### PR DESCRIPTION
## Summary
- Add unique database names to Isar test files to prevent conflicts when tests run in parallel
- Fixed tests in `recipe_repository_test.dart`, `database_provider_test.dart`, and `recipe_provider_test.dart`
- Resolves MDBX database corruption issues caused by concurrent test access

## Test plan
- [x] All 267 tests pass locally
- [x] Tests run without database conflicts

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)