### PR TITLE
Extend Recipe model with prep time, cook time, servings, difficulty, favorites, and categories (#102)

### DIFF
--- a/lib/models/recipe.dart
+++ b/lib/models/recipe.dart
@@ -2,17 +2,91 @@ import 'package:isar/isar.dart';
 
 part 'recipe.g.dart';
 
+/// Difficulty levels for recipes.
+enum RecipeDifficulty {
+  easy,
+  medium,
+  hard,
+}
+
 @collection
 class Recipe {
   Id id = Isar.autoIncrement;
 
   late String title;
 
+  /// Optional description or summary of the recipe.
+  String? description;
+
   late List<String> ingredients;
 
   late List<String> instructions;
 
+  /// Preparation time in minutes.
+  int? prepTimeMinutes;
+
+  /// Cooking time in minutes.
+  int? cookTimeMinutes;
+
+  /// Number of servings this recipe yields.
+  int? servings;
+
+  /// Recipe difficulty level (null = unspecified, 0 = easy, 1 = medium, 2 = hard).
+  /// Stored as byte in Isar (0-3 where 0 = unspecified).
+  @Index()
+  byte difficultyValue = 0;
+
+  /// Get difficulty as enum (null if unspecified).
+  @ignore
+  RecipeDifficulty? get difficulty {
+    if (difficultyValue == 0) return null;
+    return RecipeDifficulty.values[difficultyValue - 1];
+  }
+
+  /// Set difficulty from enum.
+  set difficulty(RecipeDifficulty? value) {
+    difficultyValue = value == null ? 0 : value.index + 1;
+  }
+
+  /// Whether this recipe is marked as a favorite.
+  @Index()
+  bool isFavorite = false;
+
+  /// Categories/tags for organizing recipes.
+  @Index(type: IndexType.value, caseSensitive: false)
+  List<String> categories = [];
+
   DateTime? createdAt;
 
   DateTime? updatedAt;
+
+  /// Returns the total time (prep + cook) in minutes.
+  int? get totalTimeMinutes {
+    if (prepTimeMinutes == null && cookTimeMinutes == null) return null;
+    return (prepTimeMinutes ?? 0) + (cookTimeMinutes ?? 0);
+  }
+
+  /// Returns a formatted string for the total time.
+  String? get formattedTotalTime {
+    final total = totalTimeMinutes;
+    if (total == null) return null;
+    if (total < 60) return '$total min';
+    final hours = total ~/ 60;
+    final mins = total % 60;
+    if (mins == 0) return '$hours hr';
+    return '$hours hr $mins min';
+  }
+
+  /// Returns the difficulty as a display string.
+  String? get difficultyDisplay {
+    if (difficulty == null) return null;
+    switch (difficulty!) {
+      case RecipeDifficulty.easy:
+        return 'Easy';
+      case RecipeDifficulty.medium:
+        return 'Medium';
+      case RecipeDifficulty.hard:
+        return 'Hard';
+    }
+  }
 }

--- a/lib/models/recipe.g.dart
+++ b/lib/models/recipe.g.dart
@@ -17,28 +17,78 @@ const RecipeSchema = CollectionSchema(
   name: r'Recipe',
   id: 8054415271972849591,
   properties: {
-    r'createdAt': PropertySchema(
+    r'categories': PropertySchema(
       id: 0,
+      name: r'categories',
+      type: IsarType.stringList,
+    ),
+    r'cookTimeMinutes': PropertySchema(
+      id: 1,
+      name: r'cookTimeMinutes',
+      type: IsarType.long,
+    ),
+    r'createdAt': PropertySchema(
+      id: 2,
       name: r'createdAt',
       type: IsarType.dateTime,
     ),
+    r'description': PropertySchema(
+      id: 3,
+      name: r'description',
+      type: IsarType.string,
+    ),
+    r'difficultyDisplay': PropertySchema(
+      id: 4,
+      name: r'difficultyDisplay',
+      type: IsarType.string,
+    ),
+    r'difficultyValue': PropertySchema(
+      id: 5,
+      name: r'difficultyValue',
+      type: IsarType.byte,
+    ),
+    r'formattedTotalTime': PropertySchema(
+      id: 6,
+      name: r'formattedTotalTime',
+      type: IsarType.string,
+    ),
     r'ingredients': PropertySchema(
-      id: 1,
+      id: 7,
       name: r'ingredients',
       type: IsarType.stringList,
     ),
     r'instructions': PropertySchema(
-      id: 2,
+      id: 8,
       name: r'instructions',
       type: IsarType.stringList,
     ),
+    r'isFavorite': PropertySchema(
+      id: 9,
+      name: r'isFavorite',
+      type: IsarType.bool,
+    ),
+    r'prepTimeMinutes': PropertySchema(
+      id: 10,
+      name: r'prepTimeMinutes',
+      type: IsarType.long,
+    ),
+    r'servings': PropertySchema(
+      id: 11,
+      name: r'servings',
+      type: IsarType.long,
+    ),
     r'title': PropertySchema(
-      id: 3,
+      id: 12,
       name: r'title',
       type: IsarType.string,
     ),
+    r'totalTimeMinutes': PropertySchema(
+      id: 13,
+      name: r'totalTimeMinutes',
+      type: IsarType.long,
+    ),
     r'updatedAt': PropertySchema(
-      id: 4,
+      id: 14,
       name: r'updatedAt',
       type: IsarType.dateTime,
     )
@@ -48,7 +98,47 @@ const RecipeSchema = CollectionSchema(
   deserialize: _recipeDeserialize,
   deserializeProp: _recipeDeserializeProp,
   idName: r'id',
-  indexes: {},
+  indexes: {
+    r'difficultyValue': IndexSchema(
+      id: -8662537971175837536,
+      name: r'difficultyValue',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'difficultyValue',
+          type: IndexType.value,
+          caseSensitive: false,
+        )
+      ],
+    ),
+    r'isFavorite': IndexSchema(
+      id: 5742774614603939776,
+      name: r'isFavorite',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'isFavorite',
+          type: IndexType.value,
+          caseSensitive: false,
+        )
+      ],
+    ),
+    r'categories': IndexSchema(
+      id: -7368044883450683743,
+      name: r'categories',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'categories',
+          type: IndexType.value,
+          caseSensitive: false,
+        )
+      ],
+    )
+  },
   links: {},
   embeddedSchemas: {},
   getId: _recipeGetId,
@@ -63,6 +153,31 @@ int _recipeEstimateSize(
   Map<Type, List<int>> allOffsets,
 ) {
   var bytesCount = offsets.last;
+  bytesCount += 3 + object.categories.length * 3;
+  {
+    for (var i = 0; i < object.categories.length; i++) {
+      final value = object.categories[i];
+      bytesCount += value.length * 3;
+    }
+  }
+  {
+    final value = object.description;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.difficultyDisplay;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.formattedTotalTime;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
   bytesCount += 3 + object.ingredients.length * 3;
   {
     for (var i = 0; i < object.ingredients.length; i++) {
@@ -87,11 +202,21 @@ void _recipeSerialize(
   List<int> offsets,
   Map<Type, List<int>> allOffsets,
 ) {
-  writer.writeDateTime(offsets[0], object.createdAt);
-  writer.writeStringList(offsets[1], object.ingredients);
-  writer.writeStringList(offsets[2], object.instructions);
-  writer.writeString(offsets[3], object.title);
-  writer.writeDateTime(offsets[4], object.updatedAt);
+  writer.writeStringList(offsets[0], object.categories);
+  writer.writeLong(offsets[1], object.cookTimeMinutes);
+  writer.writeDateTime(offsets[2], object.createdAt);
+  writer.writeString(offsets[3], object.description);
+  writer.writeString(offsets[4], object.difficultyDisplay);
+  writer.writeByte(offsets[5], object.difficultyValue);
+  writer.writeString(offsets[6], object.formattedTotalTime);
+  writer.writeStringList(offsets[7], object.ingredients);
+  writer.writeStringList(offsets[8], object.instructions);
+  writer.writeBool(offsets[9], object.isFavorite);
+  writer.writeLong(offsets[10], object.prepTimeMinutes);
+  writer.writeLong(offsets[11], object.servings);
+  writer.writeString(offsets[12], object.title);
+  writer.writeLong(offsets[13], object.totalTimeMinutes);
+  writer.writeDateTime(offsets[14], object.updatedAt);
 }
 
 Recipe _recipeDeserialize(
@@ -101,12 +226,19 @@ Recipe _recipeDeserialize(
   Map<Type, List<int>> allOffsets,
 ) {
   final object = Recipe();
-  object.createdAt = reader.readDateTimeOrNull(offsets[0]);
+  object.categories = reader.readStringList(offsets[0]) ?? [];
+  object.cookTimeMinutes = reader.readLongOrNull(offsets[1]);
+  object.createdAt = reader.readDateTimeOrNull(offsets[2]);
+  object.description = reader.readStringOrNull(offsets[3]);
+  object.difficultyValue = reader.readByte(offsets[5]);
   object.id = id;
-  object.ingredients = reader.readStringList(offsets[1]) ?? [];
-  object.instructions = reader.readStringList(offsets[2]) ?? [];
-  object.title = reader.readString(offsets[3]);
-  object.updatedAt = reader.readDateTimeOrNull(offsets[4]);
+  object.ingredients = reader.readStringList(offsets[7]) ?? [];
+  object.instructions = reader.readStringList(offsets[8]) ?? [];
+  object.isFavorite = reader.readBool(offsets[9]);
+  object.prepTimeMinutes = reader.readLongOrNull(offsets[10]);
+  object.servings = reader.readLongOrNull(offsets[11]);
+  object.title = reader.readString(offsets[12]);
+  object.updatedAt = reader.readDateTimeOrNull(offsets[14]);
   return object;
 }
 
@@ -118,14 +250,34 @@ P _recipeDeserializeProp<P>(
 ) {
   switch (propertyId) {
     case 0:
-      return (reader.readDateTimeOrNull(offset)) as P;
+      return (reader.readStringList(offset) ?? []) as P;
     case 1:
-      return (reader.readStringList(offset) ?? []) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 2:
-      return (reader.readStringList(offset) ?? []) as P;
+      return (reader.readDateTimeOrNull(offset)) as P;
     case 3:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 4:
+      return (reader.readStringOrNull(offset)) as P;
+    case 5:
+      return (reader.readByte(offset)) as P;
+    case 6:
+      return (reader.readStringOrNull(offset)) as P;
+    case 7:
+      return (reader.readStringList(offset) ?? []) as P;
+    case 8:
+      return (reader.readStringList(offset) ?? []) as P;
+    case 9:
+      return (reader.readBool(offset)) as P;
+    case 10:
+      return (reader.readLongOrNull(offset)) as P;
+    case 11:
+      return (reader.readLongOrNull(offset)) as P;
+    case 12:
+      return (reader.readString(offset)) as P;
+    case 13:
+      return (reader.readLongOrNull(offset)) as P;
+    case 14:
       return (reader.readDateTimeOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -148,6 +300,30 @@ extension RecipeQueryWhereSort on QueryBuilder<Recipe, Recipe, QWhere> {
   QueryBuilder<Recipe, Recipe, QAfterWhere> anyId() {
     return QueryBuilder.apply(this, (query) {
       return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhere> anyDifficultyValue() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        const IndexWhereClause.any(indexName: r'difficultyValue'),
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhere> anyIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        const IndexWhereClause.any(indexName: r'isFavorite'),
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhere> anyCategoriesElement() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        const IndexWhereClause.any(indexName: r'categories'),
+      );
     });
   }
 }
@@ -217,9 +393,571 @@ extension RecipeQueryWhere on QueryBuilder<Recipe, Recipe, QWhereClause> {
       ));
     });
   }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> difficultyValueEqualTo(
+      int difficultyValue) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'difficultyValue',
+        value: [difficultyValue],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> difficultyValueNotEqualTo(
+      int difficultyValue) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'difficultyValue',
+              lower: [],
+              upper: [difficultyValue],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'difficultyValue',
+              lower: [difficultyValue],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'difficultyValue',
+              lower: [difficultyValue],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'difficultyValue',
+              lower: [],
+              upper: [difficultyValue],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> difficultyValueGreaterThan(
+    int difficultyValue, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'difficultyValue',
+        lower: [difficultyValue],
+        includeLower: include,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> difficultyValueLessThan(
+    int difficultyValue, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'difficultyValue',
+        lower: [],
+        upper: [difficultyValue],
+        includeUpper: include,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> difficultyValueBetween(
+    int lowerDifficultyValue,
+    int upperDifficultyValue, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'difficultyValue',
+        lower: [lowerDifficultyValue],
+        includeLower: includeLower,
+        upper: [upperDifficultyValue],
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> isFavoriteEqualTo(
+      bool isFavorite) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'isFavorite',
+        value: [isFavorite],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> isFavoriteNotEqualTo(
+      bool isFavorite) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'isFavorite',
+              lower: [],
+              upper: [isFavorite],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'isFavorite',
+              lower: [isFavorite],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'isFavorite',
+              lower: [isFavorite],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'isFavorite',
+              lower: [],
+              upper: [isFavorite],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementEqualTo(
+      String categoriesElement) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'categories',
+        value: [categoriesElement],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementNotEqualTo(
+      String categoriesElement) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'categories',
+              lower: [],
+              upper: [categoriesElement],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'categories',
+              lower: [categoriesElement],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'categories',
+              lower: [categoriesElement],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'categories',
+              lower: [],
+              upper: [categoriesElement],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementGreaterThan(
+    String categoriesElement, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'categories',
+        lower: [categoriesElement],
+        includeLower: include,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementLessThan(
+    String categoriesElement, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'categories',
+        lower: [],
+        upper: [categoriesElement],
+        includeUpper: include,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementBetween(
+    String lowerCategoriesElement,
+    String upperCategoriesElement, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'categories',
+        lower: [lowerCategoriesElement],
+        includeLower: includeLower,
+        upper: [upperCategoriesElement],
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementStartsWith(
+      String CategoriesElementPrefix) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'categories',
+        lower: [CategoriesElementPrefix],
+        upper: ['$CategoriesElementPrefix\u{FFFFF}'],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause> categoriesElementIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'categories',
+        value: [''],
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterWhereClause>
+      categoriesElementIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.lessThan(
+              indexName: r'categories',
+              upper: [''],
+            ))
+            .addWhereClause(IndexWhereClause.greaterThan(
+              indexName: r'categories',
+              lower: [''],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.greaterThan(
+              indexName: r'categories',
+              lower: [''],
+            ))
+            .addWhereClause(IndexWhereClause.lessThan(
+              indexName: r'categories',
+              upper: [''],
+            ));
+      }
+    });
+  }
 }
 
 extension RecipeQueryFilter on QueryBuilder<Recipe, Recipe, QFilterCondition> {
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesElementEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'categories',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      categoriesElementGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'categories',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesElementLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'categories',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesElementBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'categories',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      categoriesElementStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'categories',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesElementEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'categories',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesElementContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'categories',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesElementMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'categories',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      categoriesElementIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'categories',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      categoriesElementIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'categories',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'categories',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'categories',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'categories',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'categories',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      categoriesLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'categories',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> categoriesLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'categories',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> cookTimeMinutesIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cookTimeMinutes',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      cookTimeMinutesIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cookTimeMinutes',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> cookTimeMinutesEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cookTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      cookTimeMinutesGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cookTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> cookTimeMinutesLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cookTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> cookTimeMinutesBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cookTimeMinutes',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterFilterCondition> createdAtIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -285,6 +1023,511 @@ extension RecipeQueryFilter on QueryBuilder<Recipe, Recipe, QFilterCondition> {
         includeLower: includeLower,
         upper: upper,
         includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'description',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'description',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'description',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'description',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'description',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> descriptionIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'description',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyDisplayIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'difficultyDisplay',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyDisplayIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'difficultyDisplay',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyDisplayEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'difficultyDisplay',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyDisplayGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'difficultyDisplay',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyDisplayLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'difficultyDisplay',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyDisplayBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'difficultyDisplay',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyDisplayStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'difficultyDisplay',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyDisplayEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'difficultyDisplay',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyDisplayContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'difficultyDisplay',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyDisplayMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'difficultyDisplay',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyDisplayIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'difficultyDisplay',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyDisplayIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'difficultyDisplay',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyValueEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'difficultyValue',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      difficultyValueGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'difficultyValue',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyValueLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'difficultyValue',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> difficultyValueBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'difficultyValue',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'formattedTotalTime',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'formattedTotalTime',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> formattedTotalTimeEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'formattedTotalTime',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'formattedTotalTime',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'formattedTotalTime',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> formattedTotalTimeBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'formattedTotalTime',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'formattedTotalTime',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'formattedTotalTime',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'formattedTotalTime',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> formattedTotalTimeMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'formattedTotalTime',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'formattedTotalTime',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      formattedTotalTimeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'formattedTotalTime',
+        value: '',
       ));
     });
   }
@@ -783,6 +2026,156 @@ extension RecipeQueryFilter on QueryBuilder<Recipe, Recipe, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> isFavoriteEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isFavorite',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> prepTimeMinutesIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'prepTimeMinutes',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      prepTimeMinutesIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'prepTimeMinutes',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> prepTimeMinutesEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'prepTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      prepTimeMinutesGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'prepTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> prepTimeMinutesLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'prepTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> prepTimeMinutesBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'prepTimeMinutes',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> servingsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'servings',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> servingsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'servings',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> servingsEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'servings',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> servingsGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'servings',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> servingsLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'servings',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> servingsBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'servings',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterFilterCondition> titleEqualTo(
     String value, {
     bool caseSensitive = true,
@@ -913,6 +2306,77 @@ extension RecipeQueryFilter on QueryBuilder<Recipe, Recipe, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> totalTimeMinutesIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'totalTimeMinutes',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      totalTimeMinutesIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'totalTimeMinutes',
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> totalTimeMinutesEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'totalTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition>
+      totalTimeMinutesGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'totalTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> totalTimeMinutesLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'totalTimeMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterFilterCondition> totalTimeMinutesBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'totalTimeMinutes',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterFilterCondition> updatedAtIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -988,6 +2452,18 @@ extension RecipeQueryObject on QueryBuilder<Recipe, Recipe, QFilterCondition> {}
 extension RecipeQueryLinks on QueryBuilder<Recipe, Recipe, QFilterCondition> {}
 
 extension RecipeQuerySortBy on QueryBuilder<Recipe, Recipe, QSortBy> {
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByCookTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cookTimeMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByCookTimeMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cookTimeMinutes', Sort.desc);
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByCreatedAt() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'createdAt', Sort.asc);
@@ -1000,6 +2476,90 @@ extension RecipeQuerySortBy on QueryBuilder<Recipe, Recipe, QSortBy> {
     });
   }
 
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByDescription() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByDescriptionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByDifficultyDisplay() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyDisplay', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByDifficultyDisplayDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyDisplay', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByDifficultyValue() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyValue', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByDifficultyValueDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyValue', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByFormattedTotalTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'formattedTotalTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByFormattedTotalTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'formattedTotalTime', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByIsFavoriteDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByPrepTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'prepTimeMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByPrepTimeMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'prepTimeMinutes', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByServings() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'servings', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByServingsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'servings', Sort.desc);
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByTitle() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'title', Sort.asc);
@@ -1009,6 +2569,18 @@ extension RecipeQuerySortBy on QueryBuilder<Recipe, Recipe, QSortBy> {
   QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByTitleDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'title', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByTotalTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'totalTimeMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> sortByTotalTimeMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'totalTimeMinutes', Sort.desc);
     });
   }
 
@@ -1026,6 +2598,18 @@ extension RecipeQuerySortBy on QueryBuilder<Recipe, Recipe, QSortBy> {
 }
 
 extension RecipeQuerySortThenBy on QueryBuilder<Recipe, Recipe, QSortThenBy> {
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByCookTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cookTimeMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByCookTimeMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cookTimeMinutes', Sort.desc);
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByCreatedAt() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'createdAt', Sort.asc);
@@ -1035,6 +2619,54 @@ extension RecipeQuerySortThenBy on QueryBuilder<Recipe, Recipe, QSortThenBy> {
   QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByCreatedAtDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByDescription() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByDescriptionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByDifficultyDisplay() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyDisplay', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByDifficultyDisplayDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyDisplay', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByDifficultyValue() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyValue', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByDifficultyValueDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'difficultyValue', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByFormattedTotalTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'formattedTotalTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByFormattedTotalTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'formattedTotalTime', Sort.desc);
     });
   }
 
@@ -1050,6 +2682,42 @@ extension RecipeQuerySortThenBy on QueryBuilder<Recipe, Recipe, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByIsFavoriteDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByPrepTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'prepTimeMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByPrepTimeMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'prepTimeMinutes', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByServings() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'servings', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByServingsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'servings', Sort.desc);
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByTitle() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'title', Sort.asc);
@@ -1059,6 +2727,18 @@ extension RecipeQuerySortThenBy on QueryBuilder<Recipe, Recipe, QSortThenBy> {
   QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByTitleDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'title', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByTotalTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'totalTimeMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QAfterSortBy> thenByTotalTimeMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'totalTimeMinutes', Sort.desc);
     });
   }
 
@@ -1076,9 +2756,50 @@ extension RecipeQuerySortThenBy on QueryBuilder<Recipe, Recipe, QSortThenBy> {
 }
 
 extension RecipeQueryWhereDistinct on QueryBuilder<Recipe, Recipe, QDistinct> {
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByCategories() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'categories');
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByCookTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cookTimeMinutes');
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QDistinct> distinctByCreatedAt() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByDescription(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'description', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByDifficultyDisplay(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'difficultyDisplay',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByDifficultyValue() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'difficultyValue');
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByFormattedTotalTime(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'formattedTotalTime',
+          caseSensitive: caseSensitive);
     });
   }
 
@@ -1094,10 +2815,34 @@ extension RecipeQueryWhereDistinct on QueryBuilder<Recipe, Recipe, QDistinct> {
     });
   }
 
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isFavorite');
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByPrepTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'prepTimeMinutes');
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByServings() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'servings');
+    });
+  }
+
   QueryBuilder<Recipe, Recipe, QDistinct> distinctByTitle(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'title', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Recipe, Recipe, QDistinct> distinctByTotalTimeMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'totalTimeMinutes');
     });
   }
 
@@ -1115,9 +2860,45 @@ extension RecipeQueryProperty on QueryBuilder<Recipe, Recipe, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Recipe, List<String>, QQueryOperations> categoriesProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'categories');
+    });
+  }
+
+  QueryBuilder<Recipe, int?, QQueryOperations> cookTimeMinutesProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cookTimeMinutes');
+    });
+  }
+
   QueryBuilder<Recipe, DateTime?, QQueryOperations> createdAtProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<Recipe, String?, QQueryOperations> descriptionProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'description');
+    });
+  }
+
+  QueryBuilder<Recipe, String?, QQueryOperations> difficultyDisplayProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'difficultyDisplay');
+    });
+  }
+
+  QueryBuilder<Recipe, int, QQueryOperations> difficultyValueProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'difficultyValue');
+    });
+  }
+
+  QueryBuilder<Recipe, String?, QQueryOperations> formattedTotalTimeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'formattedTotalTime');
     });
   }
 
@@ -1133,9 +2914,33 @@ extension RecipeQueryProperty on QueryBuilder<Recipe, Recipe, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Recipe, bool, QQueryOperations> isFavoriteProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isFavorite');
+    });
+  }
+
+  QueryBuilder<Recipe, int?, QQueryOperations> prepTimeMinutesProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'prepTimeMinutes');
+    });
+  }
+
+  QueryBuilder<Recipe, int?, QQueryOperations> servingsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'servings');
+    });
+  }
+
   QueryBuilder<Recipe, String, QQueryOperations> titleProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'title');
+    });
+  }
+
+  QueryBuilder<Recipe, int?, QQueryOperations> totalTimeMinutesProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'totalTimeMinutes');
     });
   }
 

--- a/test/models/recipe_test.dart
+++ b/test/models/recipe_test.dart
@@ -351,5 +351,320 @@ void main() {
         expect(recipe.instructions.first.contains('\n'), isTrue);
       });
     });
+
+    group('Description field', () {
+      test('should have null description by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.description, isNull);
+      });
+
+      test('should accept description', () {
+        final recipe = Recipe()..description = 'A delicious recipe';
+
+        expect(recipe.description, 'A delicious recipe');
+      });
+
+      test('should accept long description', () {
+        final longDesc = 'A' * 5000;
+        final recipe = Recipe()..description = longDesc;
+
+        expect(recipe.description?.length, 5000);
+      });
+    });
+
+    group('Time fields', () {
+      test('should have null prepTimeMinutes by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.prepTimeMinutes, isNull);
+      });
+
+      test('should accept prepTimeMinutes', () {
+        final recipe = Recipe()..prepTimeMinutes = 15;
+
+        expect(recipe.prepTimeMinutes, 15);
+      });
+
+      test('should have null cookTimeMinutes by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.cookTimeMinutes, isNull);
+      });
+
+      test('should accept cookTimeMinutes', () {
+        final recipe = Recipe()..cookTimeMinutes = 30;
+
+        expect(recipe.cookTimeMinutes, 30);
+      });
+
+      test('should accept zero for time fields', () {
+        final recipe = Recipe()
+          ..prepTimeMinutes = 0
+          ..cookTimeMinutes = 0;
+
+        expect(recipe.prepTimeMinutes, 0);
+        expect(recipe.cookTimeMinutes, 0);
+      });
+    });
+
+    group('Servings field', () {
+      test('should have null servings by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.servings, isNull);
+      });
+
+      test('should accept servings', () {
+        final recipe = Recipe()..servings = 4;
+
+        expect(recipe.servings, 4);
+      });
+
+      test('should accept single serving', () {
+        final recipe = Recipe()..servings = 1;
+
+        expect(recipe.servings, 1);
+      });
+
+      test('should accept large serving count', () {
+        final recipe = Recipe()..servings = 100;
+
+        expect(recipe.servings, 100);
+      });
+    });
+
+    group('Difficulty field', () {
+      test('should have null difficulty by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.difficulty, isNull);
+        expect(recipe.difficultyValue, 0);
+      });
+
+      test('should accept easy difficulty', () {
+        final recipe = Recipe()..difficulty = RecipeDifficulty.easy;
+
+        expect(recipe.difficulty, RecipeDifficulty.easy);
+        expect(recipe.difficultyValue, 1);
+      });
+
+      test('should accept medium difficulty', () {
+        final recipe = Recipe()..difficulty = RecipeDifficulty.medium;
+
+        expect(recipe.difficulty, RecipeDifficulty.medium);
+        expect(recipe.difficultyValue, 2);
+      });
+
+      test('should accept hard difficulty', () {
+        final recipe = Recipe()..difficulty = RecipeDifficulty.hard;
+
+        expect(recipe.difficulty, RecipeDifficulty.hard);
+        expect(recipe.difficultyValue, 3);
+      });
+
+      test('should allow clearing difficulty to null', () {
+        final recipe = Recipe()
+          ..difficulty = RecipeDifficulty.hard
+          ..difficulty = null;
+
+        expect(recipe.difficulty, isNull);
+        expect(recipe.difficultyValue, 0);
+      });
+    });
+
+    group('Favorite field', () {
+      test('should have false isFavorite by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.isFavorite, false);
+      });
+
+      test('should accept true isFavorite', () {
+        final recipe = Recipe()..isFavorite = true;
+
+        expect(recipe.isFavorite, true);
+      });
+
+      test('should allow toggling isFavorite', () {
+        final recipe = Recipe();
+        expect(recipe.isFavorite, false);
+
+        recipe.isFavorite = true;
+        expect(recipe.isFavorite, true);
+
+        recipe.isFavorite = false;
+        expect(recipe.isFavorite, false);
+      });
+    });
+
+    group('Categories field', () {
+      test('should have empty categories by default', () {
+        final recipe = Recipe();
+
+        expect(recipe.categories, isEmpty);
+      });
+
+      test('should accept single category', () {
+        final recipe = Recipe()..categories = ['Dessert'];
+
+        expect(recipe.categories, ['Dessert']);
+      });
+
+      test('should accept multiple categories', () {
+        final recipe = Recipe()..categories = ['Breakfast', 'Quick', 'Healthy'];
+
+        expect(recipe.categories.length, 3);
+        expect(recipe.categories, contains('Breakfast'));
+        expect(recipe.categories, contains('Quick'));
+        expect(recipe.categories, contains('Healthy'));
+      });
+
+      test('should preserve category order', () {
+        final recipe = Recipe()..categories = ['A', 'B', 'C'];
+
+        expect(recipe.categories[0], 'A');
+        expect(recipe.categories[1], 'B');
+        expect(recipe.categories[2], 'C');
+      });
+
+      test('should allow adding to categories', () {
+        final recipe = Recipe()..categories = ['Dinner'];
+        recipe.categories.add('Italian');
+
+        expect(recipe.categories, contains('Italian'));
+      });
+    });
+
+    group('totalTimeMinutes getter', () {
+      test('should return null when both times are null', () {
+        final recipe = Recipe();
+
+        expect(recipe.totalTimeMinutes, isNull);
+      });
+
+      test('should return prep time when cook time is null', () {
+        final recipe = Recipe()..prepTimeMinutes = 15;
+
+        expect(recipe.totalTimeMinutes, 15);
+      });
+
+      test('should return cook time when prep time is null', () {
+        final recipe = Recipe()..cookTimeMinutes = 30;
+
+        expect(recipe.totalTimeMinutes, 30);
+      });
+
+      test('should return sum of both times', () {
+        final recipe = Recipe()
+          ..prepTimeMinutes = 15
+          ..cookTimeMinutes = 30;
+
+        expect(recipe.totalTimeMinutes, 45);
+      });
+
+      test('should handle zero times', () {
+        final recipe = Recipe()
+          ..prepTimeMinutes = 0
+          ..cookTimeMinutes = 0;
+
+        expect(recipe.totalTimeMinutes, 0);
+      });
+    });
+
+    group('formattedTotalTime getter', () {
+      test('should return null when total time is null', () {
+        final recipe = Recipe();
+
+        expect(recipe.formattedTotalTime, isNull);
+      });
+
+      test('should format minutes only', () {
+        final recipe = Recipe()..prepTimeMinutes = 30;
+
+        expect(recipe.formattedTotalTime, '30 min');
+      });
+
+      test('should format hours only', () {
+        final recipe = Recipe()..cookTimeMinutes = 120;
+
+        expect(recipe.formattedTotalTime, '2 hr');
+      });
+
+      test('should format hours and minutes', () {
+        final recipe = Recipe()
+          ..prepTimeMinutes = 15
+          ..cookTimeMinutes = 75;
+
+        expect(recipe.formattedTotalTime, '1 hr 30 min');
+      });
+
+      test('should handle zero time', () {
+        final recipe = Recipe()..prepTimeMinutes = 0;
+
+        expect(recipe.formattedTotalTime, '0 min');
+      });
+    });
+
+    group('difficultyDisplay getter', () {
+      test('should return null when difficulty is null', () {
+        final recipe = Recipe();
+
+        expect(recipe.difficultyDisplay, isNull);
+      });
+
+      test('should return Easy for easy difficulty', () {
+        final recipe = Recipe()..difficulty = RecipeDifficulty.easy;
+
+        expect(recipe.difficultyDisplay, 'Easy');
+      });
+
+      test('should return Medium for medium difficulty', () {
+        final recipe = Recipe()..difficulty = RecipeDifficulty.medium;
+
+        expect(recipe.difficultyDisplay, 'Medium');
+      });
+
+      test('should return Hard for hard difficulty', () {
+        final recipe = Recipe()..difficulty = RecipeDifficulty.hard;
+
+        expect(recipe.difficultyDisplay, 'Hard');
+      });
+    });
+
+    group('Complete recipe with all fields', () {
+      test('should create recipe with all fields populated', () {
+        final now = DateTime.now();
+        final recipe = Recipe()
+          ..title = 'Complete Recipe'
+          ..description = 'A complete recipe with all fields'
+          ..ingredients = ['ingredient 1', 'ingredient 2']
+          ..instructions = ['step 1', 'step 2']
+          ..prepTimeMinutes = 15
+          ..cookTimeMinutes = 45
+          ..servings = 4
+          ..difficulty = RecipeDifficulty.medium
+          ..isFavorite = true
+          ..categories = ['Dinner', 'Italian']
+          ..createdAt = now
+          ..updatedAt = now;
+
+        expect(recipe.title, 'Complete Recipe');
+        expect(recipe.description, 'A complete recipe with all fields');
+        expect(recipe.ingredients.length, 2);
+        expect(recipe.instructions.length, 2);
+        expect(recipe.prepTimeMinutes, 15);
+        expect(recipe.cookTimeMinutes, 45);
+        expect(recipe.totalTimeMinutes, 60);
+        expect(recipe.formattedTotalTime, '1 hr');
+        expect(recipe.servings, 4);
+        expect(recipe.difficulty, RecipeDifficulty.medium);
+        expect(recipe.difficultyDisplay, 'Medium');
+        expect(recipe.isFavorite, true);
+        expect(recipe.categories.length, 2);
+        expect(recipe.createdAt, now);
+        expect(recipe.updatedAt, now);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Extends the Recipe model with new fields for a richer recipe experience
- Adds prep/cook time, servings, difficulty level, favorites, and categories
- Implements repository methods for querying by favorites and categories
- Comprehensive test coverage for all new functionality

## Changes

### Recipe Model (`lib/models/recipe.dart`)
- **New fields:**
  - `description` (optional) - Recipe summary
  - `prepTimeMinutes` (optional) - Preparation time
  - `cookTimeMinutes` (optional) - Cooking time
  - `servings` (optional) - Number of servings
  - `difficultyValue` (byte) - Stores difficulty as 0-3 (null=0, easy=1, medium=2, hard=3)
  - `isFavorite` (bool) - Favorite status with Isar index
  - `categories` (List<String>) - Tags with multi-entry index

- **New computed properties:**
  - `totalTimeMinutes` - Sum of prep + cook time
  - `formattedTotalTime` - Human-readable time (e.g., "1 hr 30 min")
  - `difficulty` - Get/set enum from byte value
  - `difficultyDisplay` - Human-readable difficulty ("Easy", "Medium", "Hard")

### Repository (`lib/repositories/recipe_repository.dart`)
- `getFavoriteRecipes()` - Get all favorited recipes
- `toggleFavorite(int id)` - Toggle favorite status
- `getRecipesByCategory(String category)` - Filter by category
- `getAllCategories()` - Get unique categories across all recipes
- `getRecipeCount()` - Total recipe count
- `getFavoriteCount()` - Favorited recipe count

### Tests
- 40+ new tests for Recipe model fields and getters
- 20+ new tests for repository methods

## Related Issue
Closes #102

## Test Plan
- [x] All existing tests pass
- [x] New model field tests pass
- [x] New repository method tests pass
- [x] Isar schema regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)