### PR TITLE
#108 Configure production app signing for Play Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-release:
-    name: Build Release APK
+    name: Build Release
     runs-on: ubuntu-latest
 
     steps:
@@ -33,13 +33,47 @@ jobs:
       - name: Run tests
         run: flutter test
 
+      # Setup signing configuration
+      - name: Decode keystore
+        if: ${{ env.KEYSTORE_BASE64 != '' }}
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/sodium-release.jks
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+
+      - name: Create key.properties
+        if: ${{ env.KEYSTORE_BASE64 != '' }}
+        run: |
+          cat > android/key.properties << EOF
+          storeFile=sodium-release.jks
+          storePassword=${{ secrets.KEYSTORE_PASSWORD }}
+          keyAlias=${{ secrets.KEY_ALIAS }}
+          keyPassword=${{ secrets.KEY_PASSWORD }}
+          EOF
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+
+      # Build release APK (for direct distribution/testing)
       - name: Build release APK
         run: flutter build apk --release
+
+      # Build release AAB (for Play Store)
+      - name: Build release AAB
+        run: flutter build appbundle --release
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: build/app/outputs/flutter-apk/app-release.apk
+          files: |
+            build/app/outputs/flutter-apk/app-release.apk
+            build/app/outputs/bundle/release/app-release.aab
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Cleanup sensitive files
+      - name: Cleanup signing files
+        if: always()
+        run: |
+          rm -f android/sodium-release.jks
+          rm -f android/key.properties

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
+# Android signing files (NEVER commit these!)
+*.jks
+*.keystore
+key.properties
+android/key.properties
+
 # Isar native binaries (downloaded during tests)
 libisar.so
 libisar.dylib

--- a/android/KEYSTORE.md
+++ b/android/KEYSTORE.md
@@ -1,0 +1,134 @@
+# Android Keystore Management
+
+This document describes how to manage the Android keystore for signing release builds of the Sodium app.
+
+## Overview
+
+Android requires all APKs/AABs to be digitally signed before installation. For Play Store distribution, you must use a consistent signing key - changing the key means you cannot update the app.
+
+## Creating a New Keystore
+
+Generate a production keystore using keytool:
+
+```bash
+keytool -genkey -v -keystore sodium-release.jks -keyalg RSA -keysize 2048 -validity 10000 -alias sodium
+```
+
+You will be prompted for:
+- Keystore password (remember this!)
+- Key password (can be same as keystore password)
+- Your name and organization details
+
+**Important:** Use a strong, unique password and store it securely.
+
+## Setting Up Local Signing
+
+1. Copy the example configuration:
+   ```bash
+   cp android/key.properties.example android/key.properties
+   ```
+
+2. Edit `android/key.properties` with your values:
+   ```properties
+   storeFile=sodium-release.jks
+   storePassword=your_actual_password
+   keyAlias=sodium
+   keyPassword=your_actual_password
+   ```
+
+3. Place your keystore file in the `android/` directory (or update the path in key.properties).
+
+4. Verify the configuration works:
+   ```bash
+   flutter build apk --release
+   ```
+
+## GitHub Actions CI/CD
+
+For automated release builds, add the following secrets to your GitHub repository:
+
+| Secret Name | Description |
+|------------|-------------|
+| `KEYSTORE_BASE64` | Base64-encoded keystore file |
+| `KEYSTORE_PASSWORD` | Keystore password |
+| `KEY_ALIAS` | Key alias (e.g., `sodium`) |
+| `KEY_PASSWORD` | Key password |
+
+### Encoding the Keystore
+
+```bash
+base64 -i android/sodium-release.jks -o keystore.base64
+# Copy contents of keystore.base64 to GitHub secret
+```
+
+### Workflow Configuration
+
+The release workflow will automatically:
+1. Decode the keystore from the secret
+2. Create key.properties
+3. Sign the release build
+
+## Backup Procedure
+
+**CRITICAL:** If you lose your keystore or passwords, you cannot update your app on Play Store!
+
+### Required Backups
+
+1. **Keystore file** (`sodium-release.jks`)
+2. **Keystore password**
+3. **Key alias**
+4. **Key password**
+
+### Recommended Backup Locations
+
+Store backups in multiple secure locations:
+
+1. **Password Manager** - Store passwords in a secure password manager (1Password, Bitwarden, etc.)
+2. **Encrypted Cloud Storage** - Keep an encrypted copy in cloud storage (Google Drive, Dropbox)
+3. **Offline Backup** - USB drive in a safe/secure location
+4. **Play App Signing** - Consider using Google Play App Signing for additional protection
+
+### Verification
+
+Periodically verify your backups work:
+
+```bash
+keytool -list -v -keystore sodium-release.jks
+```
+
+## Google Play App Signing (Recommended)
+
+For additional protection, use [Google Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play):
+
+1. Google manages your app signing key
+2. You only need to manage an upload key
+3. If you lose your upload key, Google can reset it
+4. Your app signing key is never at risk
+
+To enroll:
+1. Go to Play Console > Setup > App signing
+2. Follow the enrollment process
+3. Update your keystore to be an upload key
+
+## Security Best Practices
+
+- **Never commit** keystore files or key.properties to version control
+- **Use strong passwords** (20+ characters, mixed case, numbers, symbols)
+- **Different passwords** for keystore and key (recommended)
+- **Limit access** to keystore files and passwords
+- **Audit access** regularly if multiple developers have access
+- **Rotate upload key** if compromised (Play App Signing only)
+
+## Troubleshooting
+
+### "Keystore was tampered with"
+The keystore password is incorrect. Double-check your key.properties file.
+
+### "Cannot recover key"
+The key password is incorrect. Note that key password may differ from keystore password.
+
+### "Keystore file not found"
+Check the storeFile path in key.properties. Path is relative to the android/ directory.
+
+### Build succeeds but APK is not signed
+Ensure key.properties exists and has correct values. Check build output for signing information.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,6 +5,13 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+// Load key.properties for release signing
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "com.example.sodium"
     compileSdk = flutter.compileSdkVersion
@@ -30,11 +37,26 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias = keystoreProperties['keyAlias']
+                keyPassword = keystoreProperties['keyPassword']
+                storeFile = keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+                storePassword = keystoreProperties['storePassword']
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            // Use release signing config if available, otherwise fall back to debug for development
+            signingConfig = keystorePropertiesFile.exists() ? signingConfigs.release : signingConfigs.debug
+
+            // Enable code shrinking and optimization for release builds
+            minifyEnabled = true
+            shrinkResources = true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,48 @@
+# Flutter-specific ProGuard rules
+# Keep Flutter wrapper classes
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.**  { *; }
+-keep class io.flutter.util.**  { *; }
+-keep class io.flutter.view.**  { *; }
+-keep class io.flutter.**  { *; }
+-keep class io.flutter.plugins.**  { *; }
+
+# Keep native methods
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Keep Isar database classes
+-keep class dev.isar.** { *; }
+-keep class io.isar.** { *; }
+
+# Keep annotations
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes SourceFile,LineNumberTable
+
+# Keep Parcelable implementations
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final ** CREATOR;
+}
+
+# Keep serialization classes
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    !static !transient <fields>;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+# Remove logging in release builds
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int i(...);
+    public static int w(...);
+    public static int d(...);
+    public static int e(...);
+}

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,15 @@
+# Android Keystore Configuration
+# Copy this file to key.properties and fill in your values.
+# IMPORTANT: Never commit key.properties to version control!
+
+# Path to your keystore file (relative to android/ directory)
+storeFile=sodium-release.jks
+
+# Keystore password
+storePassword=your_keystore_password_here
+
+# Key alias (name of the key in the keystore)
+keyAlias=sodium
+
+# Key password
+keyPassword=your_key_password_here


### PR DESCRIPTION
## Summary
- Configure release signing with production keystore support
- Enable code minification and shrinkResources for smaller APKs
- Add ProGuard rules for Flutter and Isar database
- Create key.properties.example template for local development
- Add comprehensive keystore management documentation
- Update release workflow to decode keystore from GitHub secrets
- Build both APK and AAB (App Bundle) for releases

## Changes
- `android/app/build.gradle` - Release signing config, minification enabled
- `android/app/proguard-rules.pro` - ProGuard rules for Flutter/Isar
- `android/key.properties.example` - Template for local signing setup
- `android/KEYSTORE.md` - Comprehensive keystore documentation
- `.gitignore` - Exclude keystore and key.properties files
- `.github/workflows/release.yml` - Keystore decoding and AAB build

## Required GitHub Secrets
After merging, add these secrets to the repository:
- `KEYSTORE_BASE64` - Base64-encoded keystore file
- `KEYSTORE_PASSWORD` - Keystore password
- `KEY_ALIAS` - Key alias (e.g., `sodium`)
- `KEY_PASSWORD` - Key password

## Test plan
- [ ] Verify CI passes (no keystore needed for debug builds)
- [ ] Verify .gitignore correctly excludes keystore files
- [ ] Review KEYSTORE.md documentation for completeness
- [ ] After secrets are configured, verify release workflow signs builds

Closes #108
Also addresses #110 (AAB build support)