### PR TITLE
#109 Change applicationId to dev.gatzka.sodium

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "com.example.sodium"
+    namespace = "dev.gatzka.sodium"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -27,8 +27,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.sodium"
+        applicationId = "dev.gatzka.sodium"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/dev/gatzka/sodium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/gatzka/sodium/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.sodium
+package dev.gatzka.sodium
 
 import io.flutter.embedding.android.FlutterActivity
 


### PR DESCRIPTION
## Summary
- Change applicationId from `com.example.sodium` to `dev.gatzka.sodium`
- Update Android namespace accordingly
- Migrate MainActivity.kt to new package structure

## Changes
- `android/app/build.gradle` - Updated applicationId and namespace
- `android/app/src/main/kotlin/dev/gatzka/sodium/MainActivity.kt` - Relocated with updated package

## Test plan
- [ ] Verify CI builds successfully
- [ ] Verify app can be installed on device
- [ ] Verify applicationId no longer contains "example"

Closes #109