### PR TITLE
#129 Upgrade Gradle and Android Gradle Plugin versions

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.3.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary
Fixes build failures caused by outdated Gradle and Android Gradle Plugin versions.

## Changes
- Gradle: 8.3 → 8.7
- Android Gradle Plugin: 8.1.0 → 8.3.0
- Kotlin: 1.8.22 → 1.9.22

## Error Fixed
```
Flutter's minimum supported version of Android Gradle Plugin version 8.1.1
Gradle version (8.3.0) will soon be dropped. Please upgrade to at least 8.7.0
```

## Test plan
- [ ] Verify CI builds pass
- [ ] Verify app builds locally on Android

Closes #129