### PR TITLE
Fix missing ProviderScope wrapper for Riverpod

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
 
 void main() {
-  runApp(const SodiumApp());
+  runApp(const ProviderScope(child: SodiumApp()));
 }


### PR DESCRIPTION
## Summary
Fixes Riverpod initialization error by wrapping `SodiumApp` in `ProviderScope`.

## Error Fixed
```
Bad state: No ProviderScope found
```

## Changes
- Added `ProviderScope` wrapper in `main.dart`
- Added `flutter_riverpod` import